### PR TITLE
feat: add docs for general concepts; feat; add docs for endpoint reference and conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Ein Berichtselement ist eine für sich alleine stehende Darstellung von Auswertu
 
 Weitere Begriffe, die in diesem Kontext erklärungsbedürftig scheinen, werden hier in Zukunft ebenfalls erläutert.
 
+## Dokumentation
+
+Für eine ausführliche Erklärung der Konzepte und Flexibilitäten der Schnittstelle siehe die [Konzept-Dokumentation im `/docs/`-Ordner](docs/konzepte.md).
+Konventionen für offen gestaltet Teile der Spezifikation finden sich in der [Endpunkt-Referenz im `/docs/`-Ordner](docs/endpunkt-referenz.md).
+
 ## Anpassung der Spezifikation
 
 Im Ordner `/api` liegen die Quelldateien für die Spezifikation, zur besseren Wartbarkeit und leichteren Erweiterung sind diese in einzelne Dateien aufgeteilt. Diese folgen dabei auch im Einzelnen jeweils dem OpenAPI Format. Mit dem Befehl `npx @redocly/openapi-cli@latest bundle api/api.yml -o tba3-spec.yml` kann eine kombinierte Datei erzeugt werden, die alle Teile enthält und sich so leichter in Clients wie SwaggerUI laden lässt.

--- a/docs/endpunkt-referenz.md
+++ b/docs/endpunkt-referenz.md
@@ -1,0 +1,332 @@
+# TBA3-Auswertungsschnittstelle: Endpunkt-Referenz
+
+Diese Referenz richtet sich an Frontend- und Backend-Entwickler:innen. Sie beschreibt alle Endpunkte, die die Spec definiert,
+sowie die Konventionen, die auf diesen Endpunkten sinnvoll sind.
+
+Grundbegriffe (Value-Group, 3-Schichten-Architektur) sind in [Konzepte und Architektur](konzepte.md) erklärt.
+
+---
+
+## Was die Spec definiert
+
+Die Spec definiert **9 Endpunkte**: 3 Ebenen × 3 Datentypen. Jeder Endpunkt gibt ein **Array von Value-Groups** zurück.
+Was eine einzelne Value-Group repräsentiert (eine Lerngruppe, ein:e SuS, eine Schule, ein Vergleichswert …),
+hängt von der Implementierung des Backends bzw. dem Query-Parameter `type` ab.
+
+---
+
+### Kompetenzstufenverteilung (`/competence-levels`)
+
+Jede Value-Group enthält ein `competenceLevels[]`-Array. Jeder Eintrag beschreibt eine Kompetenzstufe (z.B. „Regelstandard") mit zugehöriger deskriptiver Statistik (Häufigkeit, Mittelwert, Gesamtzahl).
+
+| Ebene | Pfad | Value-Group enthält | Swagger-UI |
+|---|---|---|---|
+| Lerngruppe | `/groups/{id}/competence-levels` | `competenceLevels[]` mit Stufen + deskriptiver Statistik | [Link](https://apps.indibit.eu/tba3-api/docs#/groups/getGroupCompetenceLevels) |
+| Schule | `/schools/{id}/competence-levels` | `competenceLevels[]` mit Stufen + deskriptiver Statistik | [Link](https://apps.indibit.eu/tba3-api/docs#/schools/getSchoolCompetenceLevels) |
+| Land | `/states/{id}/competence-levels` | `competenceLevels[]` mit Stufen + deskriptiver Statistik | [Link](https://apps.indibit.eu/tba3-api/docs#/states/getStateCompetenceLevels) |
+
+---
+
+### Lösungshäufigkeiten (`/items`)
+
+Jede Value-Group enthält ein `items[]`-Array. Jeder Eintrag beschreibt ein einzelnes Item (Testaufgabe) mit Lösungshäufigkeit und optionalen Item-Parametern.
+
+| Ebene | Pfad | Value-Group enthält | Swagger-UI |
+|---|---|---|---|
+| Lerngruppe | `/groups/{id}/items` | `items[]` mit Lösungshäufigkeiten je Item | [Link](https://apps.indibit.eu/tba3-api/docs#/groups/getGroupItems) |
+| Schule | `/schools/{id}/items` | `items[]` mit Lösungshäufigkeiten je Item | [Link](https://apps.indibit.eu/tba3-api/docs#/schools/getSchoolItems) |
+| Land | `/states/{id}/items` | `items[]` mit Lösungshäufigkeiten je Item | [Link](https://apps.indibit.eu/tba3-api/docs#/states/getStateItems) |
+
+---
+
+### Aggregationen (`/aggregations`)
+
+Jede Value-Group enthält ein `aggregations[]`-Array. Jeder Eintrag beschreibt eine Aggregation nach einem bestimmten Typ (z.B. nach Kompetenz oder Geschlecht) mit deskriptiver Statistik. Welche Aggregationsarten verfügbar sind, steuert der `aggregation`-Parameter (→ Query-Parameter).
+
+| Ebene | Pfad | Value-Group enthält | Swagger-UI |
+|---|---|---|---|
+| Lerngruppe | `/groups/{id}/aggregations` | `aggregations[]` mit Typ + deskriptiver Statistik | [Link](https://apps.indibit.eu/tba3-api/docs#/groups/getGroupAggregations) |
+| Schule | `/schools/{id}/aggregations` | `aggregations[]` mit Typ + deskriptiver Statistik | [Link](https://apps.indibit.eu/tba3-api/docs#/schools/getSchoolAggregations) |
+| Land | `/states/{id}/aggregations` | `aggregations[]` mit Typ + deskriptiver Statistik | [Link](https://apps.indibit.eu/tba3-api/docs#/states/getStateAggregations) |
+
+---
+
+## Response-Inhalte einer Value-Group
+
+Zur Orientierung die Grundstruktur einer Value-Group:
+
+```
+Value-Group
+├── id           (optional) — Eindeutige Kennung
+├── name         (Pflicht)  — Bezeichnung, z.B. "Klasse 8a"
+├── domain       (optional)
+│   ├── id       (optional)
+│   └── name     (Pflicht) — z.B. "Leseverstehen"
+├── subject      (optional)
+│   ├── id       (optional)
+│   └── name     (Pflicht) — z.B. "Deutsch"
+├── covariates   (optional) — Kovariaten der Value-Group (Geschlecht, Sprache, ...)
+├── properties   (optional) — Freie Key-Value-Metadaten
+└── ... Ergebnisdaten (je nach Endpunkt)
+```
+
+Neben den endpunktspezifischen Ergebnisdaten (`competenceLevels`, `items`, `aggregations`) trägt jede Value-Group optionale Kontextfelder.
+Konzeptionell sind alle diese Felder Metadaten über die Value-Group.
+`subject` und `domain` sind bewusst als eigene Felder modelliert (nicht als Properties), weil Berichte sehr häufig nach Fach und Domäne gruppieren — sie sind strukturelle Metadaten.
+`covariates` sind typisierte Merkmale der Personen in der Gruppe.
+`properties` sind komplett freie Key-Value-Paare für alles andere.
+
+---
+
+### `type`: Typ einer Value-Group
+
+Die Value-Group trägt ein optionales `type`-Feld, das die Granularität beschreibt. So kann ein Berichtselement erkennen, was eine Value-Group repräsentiert — auch ohne den ursprünglichen Request zu kennen.
+
+| Wert | Bedeutung |
+|---|---|
+| `student` | Einzelne:r SuS |
+| `group` | Lerngruppe |
+| `school` | Schule |
+| `district` | Stadt/Gemeinde |
+| `authority` | Schulamt |
+| `state` | Bundesland |
+
+---
+
+### `subject` und `domain`: Fach und Domäne
+
+`subject` und `domain` sind eigene Response-Felder (nicht Properties), weil in Berichten fast immer nach Fach und Domäne gruppiert wird.
+
+`subject` ist ein Objekt mit `id` (optional) und `name` (Pflicht), z.B. `{ name: "Deutsch" }`.
+`domain` ist ebenfalls ein Objekt mit `id` (optional) und `name` (Pflicht). Der `name` enthält die lange Beschreibung der Domäne, z.B. `{ name: "Leseverstehen" }`.
+
+Für den **Query-Parameter** `domain` werden Kürzel für Teilbereiche eines Fachs verwendet. Die Kürzel entsprechen den Domänen-Bezeichnungen aus den Itemkennwerttabellen des IQB ([Kompetenzstufenmodelle](https://www.iqb.hu-berlin.de/de/bista/entwicklung/kompetenzstufenmodelle/)).
+
+| Fach | Fachkürzel | Mögliche Domänen-Kürzel (Query-Parameter) |
+|---|---|---|
+| Deutsch | `de` | `rs` (Rechtschreibung/Orthografie), `le` (Lesen), `ho` (Zuhören/Sprechen und Zuhören), `sp` (Sprache und Sprachgebrauch/Sprachgebrauch) |
+| Mathematik | `ma` | V8 keine, V3  `zo` (Zahlen und Operationen), `rf` (Raum und Form), `gm` (Größen und Messen), `dh` (Daten, Häufigkeiten und Wahrscheinlichkeiten), `ms` (Muster und Strukturen) |
+| Englisch | `en` | `ho` (Hörverstehen), `le` (Leseverstehen) |
+| Französisch | `fr` | `ho` (Hörverstehen), `le` (Leseverstehen) |
+
+**Wichtig: Query-Kürzel vs. Response-Objekt.** Die Kürzel in der Tabelle oben sind Werte für den `domain`-**Query-Parameter** (z.B. `?domain=rs`). Das `domain`-Feld in der **Response** ist dagegen ein Objekt mit der langen Beschreibung, z.B. `{ name: "Rechtschreibung" }`. Das Backend setzt die lange Beschreibung kontextabhängig — sie kann je nach Jahrgangsstufe variieren (z.B. `rs` = "Rechtschreibung" in der Grundschule, "Orthografie" in der Sek I).
+
+---
+
+### `covariates`: Merkmale Personen(gruppen)
+
+Array von typisierten Merkmalen auf einer Value-Group. Jede Covariate hat `type`, `label`, `value`.
+
+Vordefinierte Typen:
+
+| `type` | Beschreibung | Beispiel-`value`s |
+|---|---|---|
+| `gender` | Geschlecht | `male`, `female`, `diverse` |
+| `languageAtHome` | Sprache zu Hause | `german`, `other`, `english`, `french` |
+| `other` | Frei erweiterbar — `label` beschreibt das Merkmal | z.B. Schulform, SES, Migrationshintergrund |
+
+Für nicht-vordefinierte Merkmale steht der `other`-Typ zur Verfügung. Ob weitere freie `type`-Werte (z.B. `SES`, `schoolType`) verwendet werden können, ist noch nicht abschließend festgelegt. Aktuell beschreibt das `label` das Merkmal näher.
+
+---
+
+### `properties`: Freie Key-Value-Metadaten
+
+Komplett offene Key-Value-Paare (`key`, `value`) für systemspezifische Metadaten über die Value-Group selbst.
+
+Bekannte Beispiele:
+
+| `key`               | Beschreibung          | Beispiel               |
+|---------------------|-----------------------|------------------------|
+| `firstName`         | Vorname               | `Maria`                |
+| `lastName`          | Nachname              | `Muster`               |
+| `startTime`         | Testbeginn            | `2024-03-15T08:00:00Z` |
+| `endTime`           | Testende              | `2024-03-15T09:30:00Z` |
+| `testDuration`      | Testdauer in Sekunden | `2541`                 |
+| `schoolType`        | Schulform             | `Gymnasium`            |
+| `testPeriod`        | Durchführungszeitraum | `2024-03`              |
+| `booklet`           | Testheft-Kennung      | `V8-2024-DE-TH01`      |
+| `participationRate` | Teilnahmequote        | `0.93`                 |
+
+---
+
+### Abgrenzung: Covariates vs. Properties
+
+|                  | Covariates                               | Properties                                |
+|------------------|------------------------------------------|-------------------------------------------|
+| **Beschreiben**  | Merkmale der **Personen**(gruppe)        | Metadaten über die **Value-Group** selbst |
+| **Beispiel**     | Geschlechterverteilung, Sprachverteilung | Testdauer, Schulform, Testheft            |
+| **Struktur**     | Typisiert (`type`, `label`, `value`)     | Offene Key-Value-Paare (`key`, `value`)   |
+| **Vordefiniert** | `gender`, `languageAtHome` + `other`     | Komplett frei                             |
+
+**Faustregel:** Zusammensetzung der Personengruppe → Covariates. Kontext der Erhebung → Properties.
+
+---
+
+### Beispiel-Response: Kompetenzstufenverteilung mit Vergleichsgruppe
+
+`GET /groups/3a-deutsch/competence-levels?comparison=3b-deutsch`
+
+```json
+[
+  {
+    "name": "Klasse 3a",
+    "domain": { "name": "Leseverstehen" },
+    "subject": { "name": "Deutsch" },
+    "competenceLevels": [
+      {
+        "nameShort": "II",
+        "name": "Mindeststandard",
+        "descriptiveStatistics": { "frequency": 5, "total": 20, "mean": 0.25 }
+      },
+      {
+        "nameShort": "III",
+        "name": "Regelstandard",
+        "descriptiveStatistics": { "frequency": 10, "total": 20, "mean": 0.50 }
+      },
+      {
+        "nameShort": "IV",
+        "name": "Optimalstandard",
+        "descriptiveStatistics": { "frequency": 5, "total": 20, "mean": 0.25 }
+      }
+    ]
+  },
+  {
+    "name": "Klasse 3b",
+    "domain": { "name": "Leseverstehen" },
+    "subject": { "name": "Deutsch" },
+    "competenceLevels": [
+      {
+        "nameShort": "II",
+        "name": "Mindeststandard",
+        "descriptiveStatistics": { "frequency": 8, "total": 22, "mean": 0.36 }
+      },
+      {
+        "nameShort": "III",
+        "name": "Regelstandard",
+        "descriptiveStatistics": { "frequency": 9, "total": 22, "mean": 0.41 }
+      },
+      {
+        "nameShort": "IV",
+        "name": "Optimalstandard",
+        "descriptiveStatistics": { "frequency": 5, "total": 22, "mean": 0.23 }
+      }
+    ]
+  }
+]
+```
+
+Die erste Value-Group enthält die Ergebnisse der angefragten Lerngruppe (3a), die zweite die Vergleichsgruppe (3b). Beide tragen `domain` und `subject` als Objekte mit `name`-Feld.
+
+---
+
+## Query-Parameter: Vorgeschlagene Konventionen
+
+Die Spec definiert alle Query-Parameter als **freie Strings**. Die folgenden Konventionen sind ein **Vorschlag**.
+Jedes Backend kann eigene Werte einführen. Ein Backend muss keine dieser Konventionen übernehmen,
+sofern es Bericht und Frontend entsprechend dokumentiert.
+
+Die Query-Parameter nutzen häufig dieselben Werte wie die Response-Felder, erweitern sie aber um **Kombinierbarkeit** (kommasepariert).
+
+---
+
+### `type`: Granularität steuern
+
+Der `type`-Parameter bestimmt, welche Art von Value-Groups in der Antwort enthalten sind. Die einzelnen Werte sind unter [Response-Inhalte → type](#type-typ-einer-value-group) beschrieben.
+
+Mehrere Werte können kommasepariert übergeben werden.
+Dann liefert der Endpunkt Value-Groups für jede der kombinierten Granularitätsstufen in einer einzigen Antwort.
+
+| Pfad | `type` | Ergebnis | Mock-Server |
+|---|---|---|---|
+| `/groups/3a-deutsch/competence-levels` | `group,students` | VGs für die Lerngruppe + je SuS | [Link](https://apps.indibit.eu/tba3-api/groups/3a-deutsch/competence-levels?type=group,students) |
+| `/states/beispielland/items` | `state,district` | VGs für das Land + je Bezirk | [Link](https://apps.indibit.eu/tba3-api/states/beispielland/items?type=state,district) |
+
+Ohne `type`-Parameter entscheidet das Backend, welche Granularität es standardmäßig liefert.
+
+---
+
+### `comparison`: Vergleichswerte
+
+> **Spec = freier String.** Die Werte und ihre Bedeutung definiert das Backend, nicht die Spec.
+
+Der `comparison`-Parameter steuert, welche Vergleichs-Value-Groups zusätzlich zu den primären Ergebnissen zurückgeliefert werden. Mehrere Werte sind kommasepariert kombinierbar.
+
+**Vorgeschlagene Syntax:** Präfix `typ-id` oder nur `id`, kommasepariert — z.B. `comparison=group-3b,group-3c,landesmittelwert`
+Die Syntax ist im Backend leicht zu parsen und lässt beliebige Kombinationen zu.
+
+#### Lerngruppen-Ebene (`/groups/{id}/…`)
+
+Typische Szenarien: Vergleich mit Parallelklassen, korrigiertem Landesmittelwert, Vorjahr.
+
+| Szenario | Request-Beispiel |
+|---|---|
+| Parallelklasse(n) | `?comparison=group-3b` |
+| Korrigierter Landesmittelwert | `?comparison=landesmittelwert` |
+| Vorjahreswerte | `?comparison=year-2024,year-2023` |
+| Kombiniert | `?comparison=landesmittelwert,year-2024` |
+
+#### Schul-Ebene (`/schools/{id}/…`)
+
+Typische Szenarien: Einzelne Klassen als Vergleich einblenden, Schuljahresvergleich.
+
+| Szenario | Request-Beispiel |
+|---|---|
+| Klassen als Vergleich | `?comparison=group-3a,group-3b` |
+| Schuljahresvergleich | `?comparison=year-2024,year-2023` |
+
+#### Landes-Ebene (`/states/{id}/…`)
+
+Typische Szenarien: Bezirke, Pilotierungsgruppe.
+
+| Szenario | Request-Beispiel |
+|---|---|
+| Bezirke als Vergleich | `?comparison=bezirk-nord,bezirk-sued` |
+| Pilotierungsgruppe | `?comparison=pilotierung` |
+
+**Hinweis zum Mock-Server:** Der Mock-Server akzeptiert einfache kommaseparierte IDs ohne Typ-Präfix (z.B. `comparison=3b-deutsch`).
+
+---
+
+### `aggregation`: Aggregationsarten
+
+> **Spec = freier String.** Welche Aggregationsarten ein Backend unterstützt, ist nicht durch die Spec vorgegeben.
+
+Der `aggregation`-Parameter ist nur für den `/aggregations`-Endpunkt relevant. Er bestimmt, nach welchen Dimensionen die Ergebnisse aufgeschlüsselt werden.
+
+| Wert | Bedeutung | Mock-Server |
+|---|---|---|
+| `competence` | Nach Kompetenzen | Implementiert |
+| `gender` | Nach Geschlecht der SuS | Implementiert |
+| `exercise` | Nach Aufgabe | Nicht implementiert |
+
+Mehrere Werte können kommasepariert kombiniert werden: `aggregation=competence,gender`
+
+Mock-Server-Beispiele:
+- [/groups/3a-deutsch/aggregations?aggregation=competence](https://apps.indibit.eu/tba3-api/groups/3a-deutsch/aggregations?aggregation=competence)
+- [/groups/3a-deutsch/aggregations?aggregation=gender](https://apps.indibit.eu/tba3-api/groups/3a-deutsch/aggregations?aggregation=gender)
+
+---
+
+### `domain`: Domäne filtern
+
+> **Spec = freier String.** Der Parameter ist in `api/components/parameters.yml` definiert, aber noch nicht an Endpunkte gebunden.
+
+Der `domain`-Parameter filtert die Ergebnisse nach Domäne. Ohne diesen Parameter liefert das Backend Ergebnisse über alle Domänen.
+Die Werte und Kürzel sind unter [Response-Inhalte → subject und domain](#subject-und-domain-fach-und-domäne) beschrieben.
+
+Das Fachkürzel ist ein sinnvoller Shortcut: `domain=rs,le` ist inhaltlich gleich zu `domain=de`, wenn in einem Jahr z.B. die Domänen _Orthografie_ und _Leseverstehen_ getestet werden.
+
+**Hinweis zum Mock-Server:** Der Mock-Server liefert `domain`-Felder auf Value-Groups zurück, hat aber keinen serverseitigen Filter implementiert — der Parameter wird ignoriert.
+
+---
+
+## Fehlerverhalten
+
+| HTTP-Status | Bedeutung | Beispiel |
+|---|---|---|
+| `200` mit leerem Array | Parameter wird verstanden, aber es gibt keine Daten dafür | `?domain=sp` liefert `[]`, weil keine Sprachgebrauch-Daten vorliegen |
+| `400 Bad Request` | Syntaktisch ungültige Anfrage (in Spec definiert) | Fehlender Pfad-Parameter |
+| `404 Not Found` | Pfad-ID (group, school, state) ist unbekannt | `/groups/unbekannt/competence-levels` |
+| `501 Not Implemented` | Backend erkennt einen Query-Parameter-Wert nicht oder unterstützt ihn nicht | `?comparison=pilotierung` → `{ "message": "comparison 'pilotierung' not supported" }` |
+
+`501 Not Implemented` ist die vereinbarte Konvention, wenn ein Backend einen Parameter-Wert prinzipiell nicht unterstützt. Der Response-Body enthält eine erklärende Nachricht. Damit kann ein Frontend zwischen "keine Daten vorhanden" (200 + leeres Array) und "nicht unterstützt" (501) unterscheiden.

--- a/docs/konzepte.md
+++ b/docs/konzepte.md
@@ -1,0 +1,251 @@
+# TBA3-Auswertungsschnittstelle: Konzepte und Architektur
+
+Die TBA3-Auswertungsschnittstelle definiert ein gemeinsames Datenformat,
+mit dem Berichtselemente (UI-Komponenten) zwischen verschiedenen Projektpartnern ausgetauscht werden können,
+ohne dass sie für jedes Backend neu entwickelt werden müssen.
+
+---
+
+## Ziel: Austauschbare Berichtslemente
+
+"Austauschbar" bedeutet: Ein Berichtselement funktioniert mit den Daten anderer TBA3-konformer Backends.
+Im Optimalfall unabhängig davon, welcher Partner das Backend entwickelt hat, in welchem Bundesland es eingesetzt wird
+oder wie die zugrundeliegenden Berechnungen intern funktionieren.
+
+Idealerweise kennt ein Berichtselement nur die TBA3-OpenAPI Spezifikation. Es bekommt Daten in einem definierten Format und zeigt sie an.
+Die restlichen Fragen - welcher Kontext? welche Vergleichswerte? welche Aggregation? - steuert der aufrufende Bericht und gibt diese Informationen in das Berichtselement hinein.
+
+---
+
+## Rolle der Spezifikation
+
+```mermaid
+flowchart TD
+    subgraph report[Bericht]
+        rel1[Berichtselement]
+        rel2[Berichtselement]
+    end
+    subgraph schnittstelle[Schnittstelle]
+        spec["OpenAPI-Spezifikation\n(formeller Vertrag)"]
+        contract["Inhaltlicher Vertrag"]
+    end
+    subgraph backend[Backend]
+        data[Daten]
+        calc[Berechnungen]
+    end
+    report <-->|"Berichtsebenen?\nAntwortformat?"| spec
+    report <-->|"Vergleichsgruppen?\nAggregationen?"| contract
+    spec <-->|"Welche Endpunkte\nimplementieren?"| backend
+    contract <-->|"Verfügbare Vergleiche\nund Aggregationen?"| backend
+```
+
+| Schicht                  | Kennt                                                                                                       | Verantwortlich dafür...                                                                                                                  |
+|--------------------------|-------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| **Bericht**              | eingeloggter Benutzer, Stammdaten, Fähigkeiten des Backends                                                 | die richtigen Requests zusammenzubauen oder Kontextinformationen an Berichtselemente zu geben; braucht Informationen über BEIDE Verträge |
+| **Berichtselement**      | OpenAPI-Spec (Antwortformat, Datentypen)                                                                    | Daten/Kontextinformationen entgegenehmen und darstellen; braucht idealerweise nur die OpenAPI-Spezifikation                              |
+| **OpenAPI-Spec**         | Endpunkte, Antwortformat, Datentypen                                                                        | ein einheitliches Datenformat zu spezifizieren, das für alle Backends und Frontends als gemeinsame Basis dient                           |
+| **Inhaltlicher Vertrag** | Fähigkeiten Backend, Darstellungen Frontend, z.B. für Vergleichsgruppen, Aggregationen, Query-Param-Formate | die offenen Punkte der Schnittstelle inhaltlich auszugestalten                                                                           |
+| **Backend**              | Eigene Daten, eigene Berechnungen                                                                           | Endpunkte implementieren, Parameter verarbeiten, Berechnungen durchführen, spec-konforme Responses ausliefern                            |
+
+**OpenAPI-Spezifikation (formeller Vertrag):** Regelt die *Struktur* der Schnittstelle. Welche Endpunkte es gibt,
+welche Felder eine Response hat und welche Datentypen diese haben.
+Ein Berichtselement muss theoretisch nur diesen Vertrag kennen, um mit jedem TBA3-konformen Backend zu funktionieren.
+
+**Inhaltlicher Vertrag:** Regelt die *Semantik* der Fragen, die die Spezifikation offen lässt.
+Welche Vergleichsgruppen das Backend anbieten kann, welche Aggregationsarten unterstützt werden und wie die Parameter-Werte dafür formatiert sein müssen.
+Dieser Vertrag ist systemspezifisch und wird nicht von der OpenAPI-Spec abgedeckt. Der Bericht muss ihn kennen, um die richtigen Requests zusammenzubauen.
+
+Diese Zweiteilung wirft die Frage auf, wie weit der inhaltliche Vertrag standardisiert werden kann und welche Konsequenzen das für Flexibilität und Austauschbarkeit hat.
+
+---
+
+## Was die Spezifikation regelt
+
+### Gemeinsame Endpunkte
+
+Die Spec definiert eine 3×3-Matrix aus Berichtsebenen und Ergebnisdaten:
+
+| | Kompetenzstufen | Items | Aggregationen |
+|---|---|---|---|
+| **Lerngruppe** | `GET /groups/{id}/competence-levels` | `GET /groups/{id}/items` | `GET /groups/{id}/aggregations` |
+| **Schule** | `GET /schools/{id}/competence-levels` | `GET /schools/{id}/items` | `GET /schools/{id}/aggregations` |
+| **Land** | `GET /states/{id}/competence-levels` | `GET /states/{id}/items` | `GET /states/{id}/aggregations` |
+
+Jede Kombination ist ein eigener Endpunkt. Alle liefern dasselbe Grundformat zurück: ein Array von Value-Groups.
+
+### Gemeinsames Datenformat: Die Value-Group
+
+Die Value-Group ist der universelle Container der Spec. Alle Endpunkte liefern Arrays von Value-Groups zurück. Was eine einzelne Value-Group repräsentiert, hängt vom Kontext ab:
+
+- Eine Lerngruppe (z.B. "Klasse 8a")
+- Ein:e einzelne:r SuS (z.B. "Schüler 1")
+- Eine Schule oder ein Bundesland
+- Einen Vergleichswert (z.B. "Korrigierter Landesmittelwert")
+- Eine Teilgruppe nach Kovariate (z.B. "Mädchen in Klasse 8a")
+
+Jede Value-Group hat dieselbe Grundstruktur:
+
+```
+Value-Group
+├── id           (optional) — Eindeutige Kennung
+├── name         (Pflicht)  — Bezeichnung, z.B. "Klasse 8a"
+├── domain       (optional)
+│   ├── id       (optional)
+│   └── name     (Pflicht) — z.B. "Leseverstehen"
+├── subject      (optional)
+│   ├── id       (optional)
+│   └── name     (Pflicht) — z.B. "Deutsch"
+├── covariates   (optional) — Kovariaten der Value-Group (Geschlecht, Sprache, ...)
+├── properties   (optional) — Freie Key-Value-Metadaten
+│
+└── ... Ergebnisdaten (je nach Endpunkt)
+    ├── competenceLevels[]   ← bei /competence-levels
+    ├── items[]              ← bei /items
+    └── aggregations[]       ← bei /aggregations
+```
+
+Die Ergebnisdaten im unteren Teil der Value-Group sind endpunktspezifisch — eine Value-Group enthält immer genau einen dieser drei Typen.
+Covariates und Properties sind Erweiterungspunkte, über die systemspezifische Kontextdaten transportiert werden können.
+
+---
+
+## Was die Spec bewusst nicht regelt
+
+- **Stammdaten**: Welche Klassen, Schulen oder Lerngruppen es gibt; welche Testheftzusammensetzungen vorliegen
+- **Authentifizierung**: Wie sich ein Frontend beim Backend authentifiziert
+
+---
+
+## Offenheit vs. Standardisierung
+
+Die Spannung zwischen den beiden Teilen der Schnittstelle zeigt sich vor allem beim **inhaltlichen Vertrag**:
+Die Query-Parameter `type`, `comparison`, `aggregation` und `domain` sind als freie Strings definiert.
+Für `type` gibt es z.B. schon Beispiele in Spezifikation und Mock-Server (`students`, `group,students`, `state,district`), aber kein festes Enum.
+Ein Bericht+Backend-Paar kann eigene Werte einführen. Für `comparison`, `aggregation` und `domain` gibt es ebenfalls keine Vorgaben.
+Auch `properties` sind frei erweiterbar, und Kovariaten erlauben `other`-Typen.
+
+Diese Offenheit gibt jedem Backend maximale Flexibilität bei der Implementierung.
+Gleichzeitig bedeutet sie: **Je weniger standardisiert ist, desto schwieriger kann der Austausch von Berichtselementen zwischen Partnern werden.**
+Was `comparison=8a` konkret zurückliefert, entscheidet das Backend.
+Ohne gemeinsame Konventionen muss der Bericht die inhaltlichen Fähigkeiten jedes Backends einzeln kennen und ein Berichtselement eventuell
+Query-Parameter anders formatieren oder für fehlende/andere/zusätzliche Properties angepasst werden.
+
+Aus dieser Spannung zwischen Flexibilität und Interoperabilität ergeben sich verschiedene Stufen der Zusammenarbeit.
+
+---
+
+## Stufen der Spezifikations-Definition/Auslegung
+
+|                             | Stufe 1: OpenAPI-Spec-konform                                             | Stufe 2: Spec + Konventionen                                                                                     | Stufe 3: Vollständig ausspezifiziert                                                |
+|-----------------------------|---------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| **Was ist standardisiert?** | Endpunkte, Antwortformat, Datentypen                                      | + dokumentierte Konventionen für `comparison`, `aggregation`, `type`, `domain` (ggf. `covariates`, `properties`) | Endliche Liste aller Berichtselemente, Spec deckt jeden Anwendungsfall ab           |
+| **Was ist austauschbar?**   | Einfache/allgemeine Berichtselemente, z.B. eine Kompetenzstufenverteilung | + komplexere Elemente (z.B. Kompetenzstufenverteilung mit Vergleichsgruppen)                                     | Alle Berichtselemente vollständig austauschbar                                      |
+| **Implementierungsaufwand** | Gering: Grunddaten werden ohnehin berechnet                               | Mittel: Query-Param-Parsing, mehr Berechnungskombinationen                                                       | Explodierend: alle Berichtselemente × alle optionalen Kombinationen × alle Backends |
+| **Flexibilität**            | Maximal: jeder implementiert nur eigene Use-Cases                         | Hoch: eigene Erweiterungen bleiben möglich                                                                       | Gering: jede Änderung betrifft alle Partner                                         |
+
+### Stufe 1: OpenAPI-Spec-konform
+
+Die Mindestanforderung: Ein Backend implementiert die in der OpenAPI-Spec definierten Endpunkte und liefert Responses im vorgeschriebenen Format.
+Einfache Berichtselemente (z.B. eine Kompetenzstufenverteilung für eine einzelne Klasse) sollten sofort austauschbar sein.
+
+**Einschränkung:** Komplexere Berichtselemente, die auf Vergleichsgruppen oder Aggregationen angewiesen sind, oder unspezifizierte Properties für die Darstellung nutzen,
+benötigen bei der Verwendung mit einem anderen Backend eventuell Anpassungen, da es keine gemeinsamen Konventionen für die entsprechenden Teile gibt.
+
+### Stufe 2: OpenAPI-Spec + Konventionen (Empfehlung)
+
+Aufbauend auf Stufe 1 dokumentieren wir im Projekt Konventionen für bekannte Anwendungsfälle für Query-Parameter und offenen Response-Bestandteilen:
+Welche Werte für `comparison`, `aggregation`, `type` und `domain` verwendet werden und was sie bedeuten.
+Beziehungsweise welche Kovariaten und Properties existieren können und was diese jeweils bedeuten.
+Backends liefern für nicht unterstützte Konventionen ein `501 Not Implemented` zurück.
+
+Damit werden auch komplexere Berichtselemente austauschbarer. z.B. eine Kompetenzstufenverteilung mit Vergleichsgruppen.
+Der Aufwand steigt überwiegend auf Backend-Seite (Query-Parameter müssen geparst, zusätzliche Berechnungskombinationen unterstützt werden).
+Eigene Erweiterungen bleiben jederzeit möglich.
+
+**Der Weg von Stufe 1 zu Stufe 2 ist kurz:** Oft genügt es, sich auf Konventionen bei den Query-Parametern zu einigen, ohne die Spec selbst zu ändern.
+
+### Stufe 3 als Abgrenzung: Vollständig ausspezifiziert
+
+Die Spec definiert eine endliche, abgeschlossene Liste aller Berichtselemente und deckt jeden Anwendungsfall ab. Maximale Interoperabilität — jedes Frontend funktioniert mit jedem Backend ohne Absprachen.
+
+**Der Preis:** Explodierender Aufwand. Alle Frontends müssen mit jeder optionalen Parameterkombination umgehen können. Alle Backends müssen sämtliche Use-Cases aller Partner implementieren — auch solche, die für das eigene System irrelevant sind. Bei 4 Frontends × n Backends skaliert dieser Ansatz nicht.
+
+Diese Stufe ist **bewusst nicht** das Ziel des Projekts.
+
+---
+
+## Einfluss der Berichtselemente auf die Interoperabilität
+
+Das Stufenmodell beschreibt die Backend-Seite. Auf der Frontend-Seite stellt sich eine analoge Frage:
+Wie viel Semantik baut ein Berichtselement ein? Je mehr, desto spezifischer wird es und desto enger wird die Kopplung an den inhaltlichen Vertrag.
+Je nach Kopplungsgrad ergeben sich drei Varianten:
+
+### Variante A: Datengetrieben
+
+Das Element bekommt fertige, spec-konforme Daten (Value-Groups) hineingereicht.
+Es kennt nur das Antwortformat (OpenAPI-Spec), nicht das Backend.
+Optionale Felder und `properties` werden graceful behandelt.
+Das Element zeigt an, was vorhanden ist, und ignoriert, was fehlt.
+
+*Beispiel:* Ein Element zeigt eine Kompetenzstufenverteilung mit 0..n beliebigen Vergleichsgruppen an.
+Der Bericht ruft einen Endpunkt auf, z.B. `/groups/8a/competence-levels?comparison=class-8b,landesmittelwert`
+Das Berichtselement muss nicht wissen, welche Vergleichsgruppen es in einem spezifischen Bericht gibt (Klassen, Jahre, Landesmittelwert, ...),
+und nutzt zur Darstellung nur die Informationen, die in den Daten vorkommen (nutzt den `name` der Vergleichsgruppe als Benennung).
+
+### Variante B: Request-fähig
+
+Das Element bekommt Ebene (z.B. `groups`), eine konkrete Id (z.B. `8a`) und die konkrete ausgestaltung eines Query-Params (z.B. für die comparison `class-8b,landesmittelwert`) hineingereicht.
+Es baut den Request selbst zusammen und führt ihn aus. Welche Vergleichsgruppen es gibt, muss das Element nicht wissen.
+Es zeigt die Response spec-konform an. Dafür muss es damit umgehen, dass ein Backend bestimmte Anfragen nicht unterstützt (leere Response, `Not Implemented`).
+
+*Beispiel:* `<tba3-competence-level-comparison level="groups" id="8a" comparison="class-8b,landesmittelwert">` Das Element holt die Daten selbst und zeigt an, was kommt.
+
+### Variante C: Semantisch spezifisch
+
+Das Element ist für einen festen Anwendungsfall gebaut: Ebene und Vergleichsgruppen sind eingebaut.
+Es muss die Fähigkeiten des Backends kennen - insbesondere, wie der `comparison`-Parameter aufgebaut ist, um die gewünschten Daten zu bekommen.
+Nur die konkrete ID bleibt als Variable. Das Element kann nicht oder nur nach Anpassung wiederverwendet werden um eine andere Ebene,
+oder andere Vergleichsgruppen anzuzeigen.
+
+*Beispiel:* Ein Element zeigt die Kompetenzstufenverteilung einer Klasse mit der Verteilung des Landesmittelwerts als Vergleichsgruppe an.
+Es weiß, dass es `/groups/:id/competence-levels` mit `comparison=landesmittelwert` anfragen muss.
+
+### Übersicht
+
+| | Variante A: Datengetrieben | Variante B: Request-fähig | Variante C: Semantisch spezifisch |
+|---|---|---|---|
+| **Input** | Fertige Value-Groups | Ebene, ID, Query-Params | Nur ID |
+| **Kennt** | Nur OpenAPI-Spec | OpenAPI-Spec + Endpunkt-Struktur | OpenAPI-Spec + semantischen Vertrag |
+| **Kopplung an Backend** | Keine | Gering (Endpunkte) | Hoch (Parameter-Werte) |
+| **Entwicklungsaufwand** | Höher — muss mit allen optionalen Feldern, `properties` und variabler Anzahl von Value-Groups umgehen | Höher — wie A, plus Fehlerbehandlung bei nicht unterstützten Anfragen | Geringer — fester Scope, bekannte Datenstruktur |
+| **Fehlertoleranz** | Zeigt an, was da ist | Muss mit fehlenden Daten umgehen | Bricht, wenn Backend Semantik nicht kennt |
+
+### Interoperabilitäts-Matrix
+
+Kombiniert man die Backend-Compliance-Stufen mit den Frontend-Varianten, zeigt sich der Sweetspot:
+
+| | Variante A: Datengetrieben | Variante B: Request-fähig | Variante C: Sem. spezifisch |
+|---|---|---|---|
+| **Stufe 1** (Spec-konform) | Voll austauschbar | Austauschbar (graceful degradation) | Nur eigenes Backend |
+| **Stufe 2** (+ Konventionen) | Voll austauschbar | Voll austauschbar | Austauschbar (mit Konventionen) |
+
+
+### Dokumentation von Berichtselementen
+
+Jedes Berichtselement sollte perspektivisch eine kurze Dokumentation mitbringen, die beschreibt:
+
+- Welche Attribute/Inputs es erwartet und in welcher Variante (A, B oder C) es arbeitet
+- Welche Teile der Response es nutzt (Pflichtfelder vs. optionale Felder)
+- Bei Variante B und C: welche Backend-Fähigkeiten vorausgesetzt werden — z.B. welche `comparison`- oder `aggregation`-Werte das Backend unterstützen muss
+
+Wenn ein Element Semantik enthält, muss transparent sein, was ein Backend können muss, um das Element einzusetzen.
+Idealerweise sind die vorausgesetzten Parameter-Werte an die vereinbarten Konventionen (Stufe 2) angelehnt.
+
+Varianten A und B sind in der Entwicklung aufwändiger, weil sie mit der vollen Bandbreite optionaler Daten umgehen müssen.
+Liefern dafür maximale Austauschbarkeit schon ab Backend-Stufe 1. Variante C ist einfacher zu bauen, aber enger gekoppelt.
+
+**Empfehlung: Variante A oder B + Backend-Stufe 1 oder 2** als Sweetspot für Austauschbarkeit bei vertretbarem Aufwand.
+
+## Weiterführende Links
+
+- [Endpunkt-Referenz](endpunkt-referenz.md) — Alle Endpunkte mit Parametern und Response-Struktur


### PR DESCRIPTION
### Neue Dokumentation der TBA3-Auswertungsschnittstelle in zwei Dateien:                                             
- `docs/konzepte.md`  Konzepte und Architektur:
    - Ziel austauschbarer Berichtselemente, Rolle der OpenAPI-Spec vs. inhaltlicher Vertrag, Value-Group als universeller Container
    - 3-Stufen-Compliance-Modell (Spec-konform → Konventionen → vollständig ausspezifiziert) mit Empfehlung für Stufe 2
    - Frontend-Varianten (datengetrieben / request-fähig /   semantisch spezifisch) mit Interoperabilitäts-Matrix                                                                  
- `docs/endpunkt-referenz.md` Endpunkt-Referenz
    - Alle 9 Endpunkte (3 Ebenen × 3 Datentypen)
    - Response-Struktur einer Value-Group mit subject/domain als Objekte
    - Covariates vs. Properties, JSON-Beispiel-Response
    - vorgeschlagene Query-Parameter-Konventionen (type, comparison, aggregation, domain)
    - Fehlerverhalten (200/400/404/501)
- README.md um Links zu den neuen Docs ergänzt