### PR TITLE
WIP: Entwurf für Materialien-Schnittstellenerweiterung

### DIFF
--- a/docs/entwuerfe/materialien/README.md
+++ b/docs/entwuerfe/materialien/README.md
@@ -1,0 +1,416 @@
+# Entwurf: Materialien-Erweiterung für TBA3
+
+> Status: **Vorschlag / Entwurf** — nicht Teil der offiziellen Spec.
+> Zweck: Zur Diskussion stellen, wie Begleitmaterialien (Handreichungen, Fördermaterial,
+> Diagnosehinweise, Lesetexte, Audio/Video, Beispiel­lösungen, …) über die TBA3-Schnittstelle
+> übertragen werden können.
+
+Dieses Dokument beschreibt eine vorgeschlagene additive Erweiterung der
+TBA3-Auswertungsschnittstelle um einen eigenen Ressourcentyp **Material**. Materialien
+können an verschiedene Bezugspunkte geknüpft werden:
+
+- den **Test** als Ganzes,
+- eine **Leitidee** bzw. allgemein eine Kompetenz,
+- einzelne **Aufgaben** (`exercise`),
+- einzelne **Items** / Lösungshäufigkeiten,
+- **Kompetenzstufen**,
+- oder **allgemein** (ohne spezifischen Bezug, z. B. didaktische Hinweise zum gesamten
+  Vergleichsarbeitenwesen).
+
+Die Erweiterung ist so gestaltet, dass sie sich nahtlos in die bestehende Zweiteilung
+„OpenAPI-Spec (formeller Vertrag)" + „Inhaltlicher Vertrag" (siehe
+[`docs/konzepte.md`](../../konzepte.md)) einfügt.
+
+---
+
+## 1 · Motivation
+
+Die aktuelle TBA3-Spec deckt die statistische Auswertung ab (Kompetenzstufen­verteilungen,
+Lösungshäufigkeiten, Aggregationen). In Berichten werden aber regelmäßig zusätzlich
+**Materialien** benötigt, die über die reinen Zahlen hinausgehen, z. B.:
+
+| Kontext                             | Typisches Material                                       |
+| ----------------------------------- | -------------------------------------------------------- |
+| Test als Ganzes                     | Durchführungs­handreichung, Antwortbogen, Transkripte    |
+| Leitidee / Kompetenz                | Fachdidaktische Einordnung, Fördervorschläge             |
+| Aufgabe (`exercise`)                | Ursprüngliche Aufgabenkarte, Lösungsbeispiele            |
+| Einzelnes Item / Lösungshäufigkeit  | Musterlösung, typische Fehlermuster, Hinweis für Lehrkr. |
+| Kompetenzstufe                      | Fördermaterial für diese Stufe, Beispielaufgaben         |
+| Allgemein                           | VERA-Erklärtext, Eltern-Informationen                    |
+
+Aktuell wird dieses Material entweder außerhalb der Schnittstelle geliefert oder
+systemspezifisch in `properties` transportiert. Beides erschwert den Austausch von
+Berichtselementen zwischen Backends erheblich.
+
+Ziel dieser Erweiterung: **ein einheitlicher, flexibler und additiver Weg, Materialien
+zusammen mit Auswertungsdaten auszuliefern — ohne die bestehende Spec zu brechen.**
+
+---
+
+## 2 · Design-Leitplanken
+
+1. **Additiv & rückwärtskompatibel**: Alle neuen Felder sind optional. Ein Backend, das
+   keine Materialien anbietet, bleibt spec-konform; ein Frontend, das Materialien nicht
+   kennt, kann sie ignorieren.
+2. **Ein Material — viele Bezüge**: Dasselbe Material kann an mehrere Entitäten geknüpft
+   sein (z. B. „Förderheft Leseverstehen" ist verknüpft mit *Kompetenzstufe II* **und**
+   *Leitidee Lesen*).
+3. **Referenzielle Kompaktheit**: In Antworten werden Materialien standardmäßig nur als
+   kompakte Referenz (`MaterialReference`) eingebettet. Die vollständige Material-Ressource
+   ist über einen eigenen Endpunkt erreichbar — das hält Auswertungs­responses schlank.
+4. **Zwei Zugriffswege**: Materialien können sowohl **eingebettet** (im Kontext der
+   Auswertungsdaten) als auch **eigenständig** über einen `/materials`-Endpunkt abgefragt
+   werden.
+5. **Stufen-Modell analog zu Konzepte.md**:
+   - *Stufe 1* — Spec-konformer `/materials`-Endpunkt mit Filtern. Frontend kann Materialien
+     generisch listen/darstellen.
+   - *Stufe 2* — Konventionen für `kind`, `audience`, `attachments[].scope` usw. sind
+     dokumentiert; Berichtselemente können Materialien semantisch platzieren.
+6. **Offenheit**: Alle typisierenden Felder (`kind`, `audience`, `scope`, …) sind offene
+   Strings mit empfohlenen Werten — analog zu `type`, `comparison`, `aggregation` in der
+   bestehenden Spec.
+
+---
+
+## 3 · Datenmodell
+
+### 3.1 · `Material`
+
+Eine **eigenständige Ressource** mit ID. Trägt den Inhalt (bzw. URL) und eine Liste von
+`attachments`, die die Verknüpfung(en) zu bestehenden Entitäten beschreiben.
+
+```text
+Material
+├── id             (Pflicht)  Eindeutige Kennung
+├── title          (Pflicht)  Kurzer Titel
+├── description    (optional) Längere Beschreibung
+├── kind           (Pflicht)  Art des Materials (siehe Tabelle)
+├── format         (optional) MIME-Typ, z. B. 'application/pdf'
+├── language       (optional) BCP47, z. B. 'de', 'de-DE', 'en'
+├── url            (Pflicht*) Direktlink (kann auth-pflichtig sein)
+├── content        (optional) Inline-Inhalt für kurze Materialien (HTML/Markdown/Text)
+├── thumbnailUrl   (optional)
+├── size           (optional) Bytes
+├── duration       (optional) Sekunden (für Audio/Video)
+├── license        (optional) SPDX-Kennung oder Freitext
+├── source         (optional) z. B. 'IQB', 'VERA', 'Schulträger-XY'
+├── version        (optional)
+├── audience       (optional) 'teacher' | 'student' | 'parents' | 'other'
+├── tags[]         (optional) Freitext-Schlagworte
+├── properties[]   (optional) Key-Value-Erweiterungen (wie in value-group.yml)
+└── attachments[]  (Pflicht)  Bezugspunkte — siehe 3.2
+```
+
+*) Entweder `url` **oder** `content` muss vorhanden sein.
+
+**Vorgeschlagene Werte für `kind`** (Stufe-2-Konvention, erweiterbar):
+
+| `kind`           | Bedeutung                                                  |
+| ---------------- | ---------------------------------------------------------- |
+| `support`        | Förder-/Übungsmaterial                                     |
+| `diagnostic`     | Diagnosehinweise für Lehrkräfte                            |
+| `didactic`       | Fachdidaktische Einordnung, Handreichung                   |
+| `anchor-text`    | Aufgabentext / Lesetext / Hörtext                          |
+| `solution`       | Musterlösung, Erwartungshorizont                           |
+| `example`        | Beispielaufgabe ähnlicher Art                              |
+| `audio`          | Audiodatei (Hörverstehen)                                  |
+| `video`          | Videomaterial                                              |
+| `transcript`     | Transkript zu Audio/Video                                  |
+| `info`           | Allgemeiner Erklärtext (für SuS, Eltern, Öffentlichkeit)   |
+| `other`          | Sonstiges — `title` / `description` beschreiben das Näher. |
+
+### 3.2 · `MaterialAttachment` — die Verknüpfung
+
+Ein Material trägt **einen oder mehrere** `attachments`. Jeder Eintrag beschreibt genau
+einen Bezugspunkt:
+
+```text
+MaterialAttachment
+├── scope     (Pflicht)   'test' | 'exercise' | 'item' | 'competence'
+│                         | 'competence-level' | 'general'
+├── refId     (bedingt)   ID der verknüpften Entität (Pflicht außer bei 'general')
+├── refName   (optional)  Lesbare Kennung, falls hilfreich (z. B. '2.5.1', 'Ia')
+├── refKind   (optional)  Qualifier bei mehrdeutigen IDs, z. B. 'iqbId' vs. 'internalId'
+├── subject   (optional)  Fach, falls verknüpft (Objekt wie in value-group.yml)
+├── domain    (optional)  Domäne, falls verknüpft
+└── properties[] (optional) Freie Key-Value-Metadaten zur Verknüpfung
+```
+
+**Warum eine Liste von Attachments (nicht getrennte Felder wie `testId`, `exerciseId`, …)?**
+
+- Ein Material kann mehrfach zugeordnet sein. Eine Liste ist dafür das natürliche Modell.
+- Neue `scope`-Werte sind rückwärtskompatibel ergänzbar (konsistent zu den bestehenden
+  offen-String-Konventionen in der Spec).
+- Frontends können einheitlich über `attachments[]` iterieren, statt mehrere
+  Sonderfall-Felder zu behandeln.
+
+**`scope`-Werte im Detail**
+
+| `scope`            | `refId` verweist auf                                  | Typischer Use-Case                              |
+| ------------------ | ----------------------------------------------------- | ----------------------------------------------- |
+| `test`             | Test-/Testheft-Kennung (z. B. `V8-2024-DE-TH01`)      | Handreichung zum Gesamttest                     |
+| `exercise`         | `exercise.id`                                         | Materialien zur Aufgabe                         |
+| `item`             | `item.id` **oder** `item.iqbId` (mit `refKind`)       | Musterlösung zu einem Item                      |
+| `competence`       | `competence.id` (Kompetenz oder Leitidee)             | Fördermaterial zu einer Leitidee                |
+| `competence-level` | `competence-level.id` **oder** `competence-level.nameShort` | Fördermaterial je Stufe                  |
+| `general`          | —                                                     | Allgemeine Erklärtexte, Eltern-Informationen    |
+
+### 3.3 · `MaterialReference` — kompakte Einbettung
+
+In Auswertungs­responses werden Materialien **nicht vollständig** eingebettet, sondern nur
+als kompakte Referenz (ID + Mini-Metadaten), damit die Antworten schlank bleiben. Das volle
+Objekt ist über `GET /materials/{id}` abrufbar.
+
+```text
+MaterialReference
+├── id       (Pflicht)  Verweist auf Material.id
+├── title    (optional) Für Anzeige ohne Nachladen
+├── kind     (optional) Für Icon/Filter ohne Nachladen
+├── url      (optional) Direktlink (wenn ohne Vorverarbeitung nutzbar)
+└── audience (optional)
+```
+
+Ein Backend kann wahlweise nur `id` liefern (Frontend lädt nach) oder zusätzlich
+`title`/`kind`/`url` vorab mitgeben.
+
+Siehe YAML-Skizzen unter [`./schemas/`](./schemas/).
+
+---
+
+## 4 · Endpunkte
+
+### 4.1 · `GET /materials` — generische Materialsuche
+
+Einen einzigen neuen Endpunkt. Filter über Query-Parameter:
+
+| Parameter          | Typ                | Beschreibung                                                       |
+| ------------------ | ------------------ | ------------------------------------------------------------------ |
+| `scope`            | `string` (komma-sep) | Filter auf Attachment-Scopes (`test,exercise,item,competence,competence-level,general`) |
+| `test`             | `string`           | Testheft-Kennung                                                   |
+| `exercise`         | `string`           | Aufgabe-ID                                                         |
+| `item`             | `string`           | Item-ID oder `iqbId:AB1021`                                        |
+| `competence`       | `string`           | Kompetenz-ID (Leitidee, Kompetenz)                                 |
+| `competenceLevel`  | `string`           | Kompetenzstufen-ID oder `nameShort:Ia`                             |
+| `subject`          | `string`           | Fachkürzel (`de`, `ma`, …) — analog bestehender `domain`-Parameter |
+| `domain`           | `string`           | Domäne (`le`, `rs`, …)                                             |
+| `kind`             | `string` (komma-sep) | Material-Arten                                                     |
+| `language`         | `string`           | BCP47                                                              |
+| `audience`         | `string`           | `teacher`, `student`, `parents`, …                                 |
+
+Antwort: `200` mit Array von `Material`-Objekten.
+
+Kombinierbar: `?scope=competence-level&competenceLevel=nameShort:Ia&audience=teacher`.
+
+### 4.2 · `GET /materials/{id}` — Einzelabruf
+
+Für den Fall, dass in Auswertungs­responses nur eine `MaterialReference` (id) kam und das
+Frontend das vollständige Material nachladen will.
+
+### 4.3 · Optional: kontextsensitive Materialien pro Berichtsebene
+
+Als Ergänzung — **nicht zwingend Teil der Mindestversion**:
+
+```
+GET /groups/{id}/materials
+GET /schools/{id}/materials
+GET /states/{id}/materials
+```
+
+Diese Endpunkte können ergebnisorientiert filtern, z. B. „Liefere alle Fördermaterialien,
+die zu den tatsächlich auffälligen Items / Stufen der Klasse 8a passen." Die Entscheidung,
+welche Materialien „passen", trifft das Backend. Antwort identisch zu `/materials`.
+
+Diese Endpunkte sind eine Convenience-Schicht: semantisch gleichwertig zu
+`GET /materials?…` mit passenden Filtern, sparen dem Frontend aber die Auswertungslogik.
+
+### 4.4 · Einbettung in bestehende Responses
+
+Zusätzlich zu den Endpunkten wird ein optionales Feld `materials[]` (Array von
+`MaterialReference`) an folgenden Stellen vorgesehen:
+
+| Ort                                                 | Bedeutung                                                   |
+| --------------------------------------------------- | ----------------------------------------------------------- |
+| `value-group.yml`                                   | Materialien mit Bezug zur gesamten Wertegruppe / zum Test   |
+| `exercise.yml`                                      | Materialien zur Aufgabe                                     |
+| `item.yml` (damit auch in `/items`-Response)        | Materialien zum Item (Musterlösung, Fehlermuster)           |
+| `competence.yml` (via `aggregations`)               | Materialien zu Kompetenz/Leitidee                           |
+| `competence-level.yml` (via `/competence-levels`)   | Materialien je Stufe                                        |
+
+Bei hoher Materialanzahl **sollte** das Backend hier nur die wichtigsten oder gar keine
+Referenzen inline liefern und auf `/materials?…` verweisen — Analogie zu Paginierung.
+
+---
+
+## 5 · Fehlerverhalten
+
+Konsistent zu den Konventionen aus der Endpunkt-Referenz:
+
+| HTTP            | Bedeutung                                                                     |
+| --------------- | ----------------------------------------------------------------------------- |
+| `200` + `[]`    | Filter verstanden, aber keine passenden Materialien vorhanden                 |
+| `400`           | Syntaktisch ungültige Anfrage                                                 |
+| `404`           | `/materials/{id}` — Material nicht gefunden                                   |
+| `501`           | Backend unterstützt einen Filter-Wert prinzipiell nicht (z. B. unbekanntes `scope`) |
+
+---
+
+## 6 · Beispiele
+
+Konkrete JSON-Beispiele liegen unter [`./beispiele/`](./beispiele/):
+
+- [`material-list.json`](./beispiele/material-list.json) — Response von `GET /materials?scope=competence-level&competenceLevel=nameShort:Ia`
+- [`competence-levels-with-materials.json`](./beispiele/competence-levels-with-materials.json) — `/groups/{id}/competence-levels` mit eingebetteten `materials[]`-Referenzen pro Stufe
+- [`items-with-materials.json`](./beispiele/items-with-materials.json) — `/groups/{id}/items` mit Musterlösungs-Referenzen pro Item
+
+---
+
+## 7 · YAML-Schema-Skizzen
+
+Die OpenAPI-YAML-Dateien liegen unter [`./schemas/`](./schemas/) bzw. [`./paths/`](./paths/)
+und folgen demselben Aufbau wie `api/components/schemas/` im Hauptverzeichnis.
+
+Für eine Integration in die offizielle Spec wären folgende Schritte nötig:
+
+1. `api/components/schemas/material.yml`, `material-attachment.yml`,
+   `material-reference.yml` anlegen (kopiert aus `./schemas/`).
+2. `api/paths/materials/list.yml` und `api/paths/materials/by-id.yml` anlegen.
+3. In `api/api.yml` die neuen Pfade und einen neuen Tag `materials` registrieren.
+4. Die bestehenden Schemas `value-group.yml`, `exercise.yml`, `item.yml`, `competence.yml`,
+   `competence-level.yml` um ein optionales `materials`-Feld ergänzen.
+5. Parameter-Definitionen in `api/components/parameters.yml` ergänzen.
+
+---
+
+## 8 · Verhältnis zu LOM, LRMI und AMB
+
+Für Bildungs­ressourcen existieren etablierte Metadatenstandards, die in großen
+OER-Infrastrukturen (edu-sharing, WirLernenOnline, Deutscher Bildungsserver, Mundo, …)
+bereits verwendet werden:
+
+| Standard     | Beschreibung                                                                   |
+| ------------ | ------------------------------------------------------------------------------ |
+| **LOM**      | IEEE 1484.12.1 *Learning Object Metadata* — umfangreich, XML-geprägt, ~80 Felder |
+| **LRMI**     | *Learning Resource Metadata Initiative* — auf schema.org aufsetzende, schlanke Erweiterung; JSON-LD-freundlich |
+| **AMB**      | *Allgemeines Metadatenprofil für Bildungsressourcen* der DINI-AG KIM — deutsches Anwendungsprofil von LRMI/schema.org; in DE der De-facto-Standard für neue OER-Plattformen |
+
+### Warum TBA3 diese Standards **nicht nachbaut**
+
+Die TBA3-Spec folgt dem Leitbild aus [`konzepte.md`](../../konzepte.md):
+Stufe 3 (vollständige Standardisierung) ist bewusst nicht das Ziel. LOM/LRMI in
+voller Breite in der Auswertungs­schnittstelle abzubilden würde
+
+- Backends zwingen, Metadatenfelder zu produzieren, die kein Frontend anzeigt,
+- eine zweite parallele Modellierung neben `attachments[]`/`properties` schaffen,
+- die Bindung an ein spezifisches Bildungs­metadaten-Ökosystem erzwingen, obwohl
+  TBA3 primär eine *Auswertungs*­schnittstelle ist.
+
+### Warum ein schlanker Brückenmechanismus trotzdem sinnvoll ist
+
+Materialien, die in der Rückmeldung erscheinen, existieren oft schon in einem
+LRMI/AMB-konformen Repository. Frontends im OER-Ökosystem profitieren, wenn sie auf den
+reichen Metadatensatz durchgreifen können, ohne ihn in TBA3 zu duplizieren.
+
+### Lösung: drei kleine Brückenpunkte
+
+**1. `Material.externalMetadata[]`** — optionaler Verweis auf externe Metadatensätze.
+
+```json
+"externalMetadata": [
+  {
+    "schema": "amb",
+    "url": "https://wirlernenonline.de/entry/9a21ad44.jsonld",
+    "mediaType": "application/ld+json"
+  }
+]
+```
+
+Kosten: ein optionales Array. Nutzen: LRMI-fähige Frontends dereferenzieren bei Bedarf
+und erhalten den vollen AMB-Datensatz. Schlichte Frontends ignorieren das Feld.
+
+**2. `MaterialAttachment.refKind: 'curriculumUri'`** — Bezugspunkte dürfen als URI aus
+einem Kompetenz-/Curriculum-Vokabular angegeben werden (z. B. aus dem KMK-Bildungs­standards-
+oder Lehrplan-Vokabular). Diese URIs passen ohne Umrechnung in LRMI/AMB
+`alignmentObject.targetUrl` (`alignmentType ∈ {teaches, assesses, requires, …}`).
+
+```json
+{
+  "scope": "competence",
+  "refId": "https://w3id.org/kim/schulfaecher/s1002",
+  "refKind": "curriculumUri",
+  "refName": "Leitidee Lesen"
+}
+```
+
+**3. `Material.kind` als Stufe-2-Konvention an AMB/LRMI-`learningResourceType` angelehnt**
+
+`kind` bleibt ein kleines, kontrolliertes Vokabular für einfache Berichtselemente
+(Icon/Filter/Platzierung). Wer feingranularere Klassifikation braucht, nutzt
+`externalMetadata` und erhält dort `learningResourceType` aus einem Vokabular wie
+`https://w3id.org/kim/hcrt/`.
+
+Empfohlenes Mapping:
+
+| TBA3 `kind`    | AMB / LRMI `learningResourceType` (Vokabular `w3id.org/kim/hcrt/`) | Bemerkung                   |
+| -------------- | ------------------------------------------------------------------ | --------------------------- |
+| `support`      | `worksheet`, `exercise`, `drill_and_practice`                      | Feinere Unterscheidung via externalMetadata |
+| `didactic`     | `teaching_module`, `guide`, `lesson_plan`                          |                             |
+| `anchor-text`  | `text`, `reading`                                                  | Lesetext/Aufgabenstamm      |
+| `solution`     | `assessment` + Zusatzkontext im LRMI-Datensatz (`solution`)        | LRMI `EducationalAssessment` bietet mehr Felder |
+| `example`      | `assessment`, `case_study`                                         |                             |
+| `audio`        | `audio`                                                            | 1:1                         |
+| `video`        | `video`                                                            | 1:1                         |
+| `transcript`   | `transcript`                                                       | 1:1                         |
+| `info`         | `web_page`, `other`                                                |                             |
+| `other`        | `other`                                                            |                             |
+
+### Was das NICHT ist
+
+- **Kein LOM-Parser in der Spec.** TBA3 definiert nur, *dass* verlinkt werden kann,
+  nicht *wie* LRMI/AMB selbst aufgebaut ist — dafür gilt der jeweilige Standard.
+- **Keine Pflicht.** Ein Backend ohne OER-Anbindung lässt `externalMetadata` einfach weg.
+- **Keine Datenkopie.** Die TBA3-Kernfelder (`title`, `kind`, `url`, `license`, …)
+  bleiben die kanonische Quelle für das, was in einem TBA3-Bericht gezeigt wird.
+  `externalMetadata` ist nur eine Brücke, keine Schattenkopie.
+
+---
+
+## 9 · Offene Punkte / Diskussion
+
+- **Authentifizierung von `url`**: Muss ein Frontend mit der gleichen Auth wie die TBA3-API
+  auf die Material-URL zugreifen können? Vorschlag: Offenlassen; Backend dokumentiert
+  Verhalten (z. B. pre-signed URLs).
+- **Caching / Versionierung**: Sollten Materialien ETag/Last-Modified tragen? Vorschlag:
+  HTTP-Standardheader nutzen, nichts Zusätzliches in der Spec.
+- **Inline vs. URL**: Wann sollte `content` (Inline) statt `url` genutzt werden?
+  Vorschlag: Nur für kleine, selbstenthaltende Texte (z. B. kurze Hinweise ≤ 5 KB).
+- **Mehrsprachigkeit**: Reicht `language` pro Material, oder sollte ein Material
+  Übersetzungen als Varianten tragen? Vorschlag: Ein Material pro Sprache, Übersetzungen
+  via gemeinsame `tags` oder `properties[key=translationOf]` verknüpfen.
+- **Reihenfolge/Relevanz**: Soll `MaterialReference` eine `relevance` oder `priority`
+  tragen? Oder sortiert das Backend implizit?
+- **`test`-Scope**: Soll `test` eine eigene Entität in der Spec werden, oder reicht ein
+  freier String als `refId`? Vorschlag: Freier String (analog Booklets in `properties`).
+- **Zusammenspiel mit `properties`**: Dürfen Materialien auch in Value-Group-`properties`
+  weiterhin als Link gelistet werden? Vorschlag: Ja, aber `materials[]` ist für neue
+  Implementierungen der kanonische Ort.
+
+---
+
+## 10 · Zusammenfassung
+
+Die vorgeschlagene Erweiterung
+
+- führt **eine neue Ressource** `Material` mit frei definierbaren Bezugspunkten
+  (`attachments[]`) ein,
+- ergänzt die Spec um **einen zwingenden neuen Endpunkt** `GET /materials` (+
+  `/materials/{id}`) und eine **optionale Convenience-Schicht** pro Ebene,
+- erweitert bestehende Schemas **rückwärtskompatibel** um ein optionales
+  `materials[]`-Referenzfeld,
+- bietet über `externalMetadata[]`, `refKind: curriculumUri` und ein AMB-nahes
+  `kind`-Vokabular eine **schlanke Brücke zu LRMI/AMB/LOM**, ohne diese Standards
+  in der Spec nachzubauen,
+- bleibt der Spec-Philosophie („offen wo möglich, Konventionen wo sinnvoll") treu.
+
+Damit können Berichte und Berichtselemente neben den reinen Auswertungsdaten auch das
+zugehörige Begleit- und Fördermaterial einheitlich konsumieren — sowohl testweit als auch
+präzise an Leitidee, Aufgabe, Item, Lösungshäufigkeit oder Kompetenzstufe hängend.

--- a/docs/entwuerfe/materialien/README.md
+++ b/docs/entwuerfe/materialien/README.md
@@ -261,6 +261,10 @@ Konkrete JSON-Beispiele liegen unter [`./beispiele/`](./beispiele/):
 - [`material-list.json`](./beispiele/material-list.json) — Response von `GET /materials?scope=competence-level&competenceLevel=nameShort:Ia`
 - [`competence-levels-with-materials.json`](./beispiele/competence-levels-with-materials.json) — `/groups/{id}/competence-levels` mit eingebetteten `materials[]`-Referenzen pro Stufe
 - [`items-with-materials.json`](./beispiele/items-with-materials.json) — `/groups/{id}/items` mit Musterlösungs-Referenzen pro Item
+- [`msk-material-list.json`](./beispiele/msk-material-list.json) — MSK-orientierte Materialliste (Leitprinzipien, Vor-Check, Foerderbausteine, Online-Check)
+- [`msk-competence-levels-with-materials.json`](./beispiele/msk-competence-levels-with-materials.json) — Kompetenzstufenbeispiel fuer eine MSK-Foerdergruppe in Mathematik
+- [`msk-items-with-materials.json`](./beispiele/msk-items-with-materials.json) — Item-/Aufgabenbeispiel mit Vor-Check/Foerdereinheiten aus dem MSK-Kontext
+- [`msk-aggregations-with-materials.json`](./beispiele/msk-aggregations-with-materials.json) — Aggregationsbeispiel entlang der MSK-Leitprinzipien
 
 ---
 

--- a/docs/entwuerfe/materialien/README.md
+++ b/docs/entwuerfe/materialien/README.md
@@ -258,13 +258,14 @@ Konsistent zu den Konventionen aus der Endpunkt-Referenz:
 
 Konkrete JSON-Beispiele liegen unter [`./beispiele/`](./beispiele/):
 
-- [`material-list.json`](./beispiele/material-list.json) — Response von `GET /materials?scope=competence-level&competenceLevel=nameShort:Ia`
+- [`material-list.json`](./beispiele/material-list.json) — Response von `GET /materials?test=V8-2024-DE-TH01` — alle Materialien eines Tests; deckt alle `kind`-Werte (`support`, `didactic`, `anchor-text`, `solution`, `diagnostic`, `example`, `info`, `video`) und alle `audience`-Werte (`teacher`, `student`, `parents`) ab
 - [`competence-levels-with-materials.json`](./beispiele/competence-levels-with-materials.json) — `/groups/{id}/competence-levels` mit eingebetteten `materials[]`-Referenzen pro Stufe
 - [`items-with-materials.json`](./beispiele/items-with-materials.json) — `/groups/{id}/items` mit Musterlösungs-Referenzen pro Item
 - [`msk-material-list.json`](./beispiele/msk-material-list.json) — MSK-orientierte Materialliste (Leitprinzipien, Vor-Check, Foerderbausteine, Online-Check)
 - [`msk-competence-levels-with-materials.json`](./beispiele/msk-competence-levels-with-materials.json) — Kompetenzstufenbeispiel fuer eine MSK-Foerdergruppe in Mathematik
 - [`msk-items-with-materials.json`](./beispiele/msk-items-with-materials.json) — Item-/Aufgabenbeispiel mit Vor-Check/Foerdereinheiten aus dem MSK-Kontext
 - [`msk-aggregations-with-materials.json`](./beispiele/msk-aggregations-with-materials.json) — Aggregationsbeispiel entlang der MSK-Leitprinzipien
+- [`vera-englisch-hoerverstehen-items.json`](./beispiele/vera-englisch-hoerverstehen-items.json) — VERA-8 Englisch Hörverstehen; zeigt `audio`- und `transcript`-Materialien an Aufgaben, zwei Hörtext-Aufgaben teilen sich dieselbe Exercise-Ressource
 
 ---
 

--- a/docs/entwuerfe/materialien/beispiele/competence-levels-with-materials.json
+++ b/docs/entwuerfe/materialien/beispiele/competence-levels-with-materials.json
@@ -1,0 +1,53 @@
+[
+  {
+    "name": "Klasse 3a",
+    "type": "group",
+    "domain": { "name": "Leseverstehen" },
+    "subject": { "name": "Deutsch" },
+    "materials": [
+      {
+        "id": "41d3f4b7-8c2b-4c11-8ad4-6e3c7e9c3a0b",
+        "title": "Durchführungshandreichung VERA-8 Deutsch 2024",
+        "kind": "didactic",
+        "audience": "teacher"
+      }
+    ],
+    "competenceLevels": [
+      {
+        "nameShort": "Ia",
+        "name": "Unter Mindeststandard",
+        "descriptiveStatistics": { "frequency": 3, "total": 20, "mean": 0.15 },
+        "materials": [
+          {
+            "id": "9a21ad44-3e8b-4a1e-9f76-2a1e8a6b0e5a",
+            "title": "Förderheft Leseverstehen — Stufe Ia",
+            "kind": "support",
+            "audience": "teacher"
+          }
+        ]
+      },
+      {
+        "nameShort": "II",
+        "name": "Mindeststandard",
+        "descriptiveStatistics": { "frequency": 5, "total": 20, "mean": 0.25 },
+        "materials": [
+          {
+            "id": "b1e7a9c4-2205-4cbd-9f61-1c7d5fa3b4c7",
+            "title": "Übungen zu Stufe II — Leseverstehen",
+            "kind": "support"
+          }
+        ]
+      },
+      {
+        "nameShort": "III",
+        "name": "Regelstandard",
+        "descriptiveStatistics": { "frequency": 10, "total": 20, "mean": 0.50 }
+      },
+      {
+        "nameShort": "IV",
+        "name": "Optimalstandard",
+        "descriptiveStatistics": { "frequency": 2, "total": 20, "mean": 0.10 }
+      }
+    ]
+  }
+]

--- a/docs/entwuerfe/materialien/beispiele/competence-levels-with-materials.json
+++ b/docs/entwuerfe/materialien/beispiele/competence-levels-with-materials.json
@@ -41,12 +41,34 @@
       {
         "nameShort": "III",
         "name": "Regelstandard",
-        "descriptiveStatistics": { "frequency": 10, "total": 20, "mean": 0.50 }
+        "descriptiveStatistics": { "frequency": 10, "total": 20, "mean": 0.50 },
+        "materials": [
+          {
+            "id": "a7b8c9d0-e1f2-4a3b-8c4d-5e6f7a8b9c0d",
+            "title": "Vertiefungsaufgaben Leseverstehen — Stufe III",
+            "kind": "example",
+            "audience": "teacher"
+          }
+        ]
       },
       {
         "nameShort": "IV",
         "name": "Optimalstandard",
-        "descriptiveStatistics": { "frequency": 2, "total": 20, "mean": 0.10 }
+        "descriptiveStatistics": { "frequency": 2, "total": 20, "mean": 0.10 },
+        "materials": [
+          {
+            "id": "f1e2d3c4-b5a6-4978-8b9c-0d1e2f3a4b5c",
+            "title": "Enrichment: Anspruchsvolle Leseaufgaben — Stufe IV",
+            "kind": "example",
+            "audience": "teacher"
+          },
+          {
+            "id": "b2c3d4e5-f6a7-48b9-9c0d-1e2f3a4b5c6d",
+            "title": "Lesetipps für starke Leserinnen und Leser",
+            "kind": "info",
+            "audience": "student"
+          }
+        ]
       }
     ]
   }

--- a/docs/entwuerfe/materialien/beispiele/items-with-materials.json
+++ b/docs/entwuerfe/materialien/beispiele/items-with-materials.json
@@ -1,0 +1,48 @@
+[
+  {
+    "name": "Klasse 3a",
+    "type": "group",
+    "subject": { "name": "Deutsch" },
+    "items": [
+      {
+        "id": "b8d23653-3881-40de-a45a-d34e2dd191ed",
+        "name": "2.1",
+        "position": 1,
+        "iqbId": "AB1021",
+        "exercise": {
+          "name": "At the Summer Camp",
+          "materials": [
+            {
+              "id": "2c4f8e76-0b1d-4a3a-9a4f-0f35cda1b7e2",
+              "title": "Aufgabenkarte 'At the Summer Camp'",
+              "kind": "anchor-text"
+            }
+          ]
+        },
+        "descriptiveStatistics": { "frequency": 12, "total": 20, "mean": 0.60 },
+        "materials": [
+          {
+            "id": "c7e4eb11-2dbc-4c9b-bac0-7e3b7d2a5a91",
+            "title": "Musterlösung Item 2.1",
+            "kind": "solution",
+            "audience": "teacher"
+          },
+          {
+            "id": "f9b0a132-4c8a-41d2-94c7-8e3a5d9f6e12",
+            "title": "Typische Fehlermuster zu Item 2.1",
+            "kind": "diagnostic",
+            "audience": "teacher"
+          }
+        ]
+      },
+      {
+        "id": "6a37d9b0-3e4b-4c7a-9e5f-5b1a2c3d4e5f",
+        "name": "2.2",
+        "position": 2,
+        "iqbId": "AB1022",
+        "exercise": { "name": "At the Summer Camp" },
+        "descriptiveStatistics": { "frequency": 8, "total": 20, "mean": 0.40 }
+      }
+    ]
+  }
+]

--- a/docs/entwuerfe/materialien/beispiele/items-with-materials.json
+++ b/docs/entwuerfe/materialien/beispiele/items-with-materials.json
@@ -40,8 +40,31 @@
         "name": "2.2",
         "position": 2,
         "iqbId": "AB1022",
-        "exercise": { "name": "At the Summer Camp" },
-        "descriptiveStatistics": { "frequency": 8, "total": 20, "mean": 0.40 }
+        "exercise": {
+          "name": "At the Summer Camp",
+          "materials": [
+            {
+              "id": "2c4f8e76-0b1d-4a3a-9a4f-0f35cda1b7e2",
+              "title": "Aufgabenkarte 'At the Summer Camp'",
+              "kind": "anchor-text"
+            }
+          ]
+        },
+        "descriptiveStatistics": { "frequency": 8, "total": 20, "mean": 0.40 },
+        "materials": [
+          {
+            "id": "e3f4a5b6-c7d8-49e0-af1b-2c3d4e5f6a7b",
+            "title": "Musterlösung Item 2.2",
+            "kind": "solution",
+            "audience": "teacher"
+          },
+          {
+            "id": "d5e6f7a8-b9c0-4d1e-be2f-3a4b5c6d7e8f",
+            "title": "Typische Fehlermuster zu Item 2.2",
+            "kind": "diagnostic",
+            "audience": "teacher"
+          }
+        ]
       }
     ]
   }

--- a/docs/entwuerfe/materialien/beispiele/material-list.json
+++ b/docs/entwuerfe/materialien/beispiele/material-list.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "9a21ad44-3e8b-4a1e-9f76-2a1e8a6b0e5a",
+    "title": "Förderheft Leseverstehen — Stufe Ia",
+    "description": "Differenzierte Übungen zum sinnentnehmenden Lesen auf Stufe Ia.",
+    "kind": "support",
+    "format": "application/pdf",
+    "language": "de",
+    "url": "https://materials.example.org/foerderheft-lesen-ia.pdf",
+    "audience": "teacher",
+    "source": "IQB",
+    "license": "IQB Nutzungsbedingungen",
+    "tags": ["Lesen", "Förderung"],
+    "attachments": [
+      {
+        "scope": "competence-level",
+        "refId": "18488a76-0cb6-4d16-9f7b-d2c69f73e058",
+        "refName": "Ia",
+        "refKind": "nameShort",
+        "subject": { "name": "Deutsch" },
+        "domain": { "name": "Leseverstehen" }
+      },
+      {
+        "scope": "competence",
+        "refId": "https://w3id.org/kim/schulfaecher/s1002",
+        "refName": "Leitidee Lesen",
+        "refKind": "curriculumUri",
+        "subject": { "name": "Deutsch" }
+      }
+    ],
+    "externalMetadata": [
+      {
+        "schema": "amb",
+        "url": "https://wirlernenonline.de/entry/9a21ad44.jsonld",
+        "mediaType": "application/ld+json"
+      }
+    ]
+  },
+  {
+    "id": "c7e4eb11-2dbc-4c9b-bac0-7e3b7d2a5a91",
+    "title": "Musterlösung Item 2.1",
+    "kind": "solution",
+    "format": "application/pdf",
+    "language": "de",
+    "url": "https://materials.example.org/musterloesung-ab1021.pdf",
+    "audience": "teacher",
+    "attachments": [
+      {
+        "scope": "item",
+        "refId": "AB1021",
+        "refKind": "iqbId"
+      }
+    ]
+  },
+  {
+    "id": "41d3f4b7-8c2b-4c11-8ad4-6e3c7e9c3a0b",
+    "title": "Durchführungshandreichung VERA-8 Deutsch 2024",
+    "kind": "didactic",
+    "format": "application/pdf",
+    "language": "de",
+    "url": "https://materials.example.org/vera8-de-2024-handreichung.pdf",
+    "audience": "teacher",
+    "attachments": [
+      { "scope": "test", "refId": "V8-2024-DE-TH01" }
+    ]
+  },
+  {
+    "id": "d02fe6f7-3a14-4e0c-8d77-9fd3a1f4b2c3",
+    "title": "Eltern-Infoblatt zur Rückmeldung",
+    "kind": "info",
+    "format": "text/html",
+    "language": "de",
+    "content": "<h1>Was bedeutet das Testergebnis Ihres Kindes?</h1><p>…</p>",
+    "audience": "parents",
+    "attachments": [
+      { "scope": "general" }
+    ]
+  }
+]

--- a/docs/entwuerfe/materialien/beispiele/material-list.json
+++ b/docs/entwuerfe/materialien/beispiele/material-list.json
@@ -75,5 +75,155 @@
     "attachments": [
       { "scope": "general" }
     ]
+  },
+  {
+    "id": "2c4f8e76-0b1d-4a3a-9a4f-0f35cda1b7e2",
+    "title": "Aufgabenkarte 'At the Summer Camp'",
+    "description": "Originaltext und Abbildungen zur Aufgabe 'At the Summer Camp' (Items 2.1 und 2.2).",
+    "kind": "anchor-text",
+    "format": "application/pdf",
+    "language": "de",
+    "url": "https://materials.example.org/vera8-de-aufgabe-summer-camp.pdf",
+    "source": "IQB",
+    "license": "IQB Nutzungsbedingungen",
+    "attachments": [
+      {
+        "scope": "exercise",
+        "refId": "ex-at-the-summer-camp-001",
+        "refName": "At the Summer Camp",
+        "subject": { "name": "Deutsch" },
+        "domain": { "name": "Leseverstehen" }
+      }
+    ]
+  },
+  {
+    "id": "f9b0a132-4c8a-41d2-94c7-8e3a5d9f6e12",
+    "title": "Typische Fehlermuster zu Item 2.1",
+    "description": "Häufige Schülerantworten, Bewertungshinweise und diagnostische Einordnung.",
+    "kind": "diagnostic",
+    "format": "application/pdf",
+    "language": "de",
+    "url": "https://materials.example.org/fehlermuster-ab1021.pdf",
+    "audience": "teacher",
+    "source": "IQB",
+    "attachments": [
+      {
+        "scope": "item",
+        "refId": "AB1021",
+        "refKind": "iqbId"
+      }
+    ]
+  },
+  {
+    "id": "e3f4a5b6-c7d8-49e0-af1b-2c3d4e5f6a7b",
+    "title": "Musterlösung Item 2.2",
+    "kind": "solution",
+    "format": "application/pdf",
+    "language": "de",
+    "url": "https://materials.example.org/musterloesung-ab1022.pdf",
+    "audience": "teacher",
+    "source": "IQB",
+    "attachments": [
+      {
+        "scope": "item",
+        "refId": "AB1022",
+        "refKind": "iqbId"
+      }
+    ]
+  },
+  {
+    "id": "b1e7a9c4-2205-4cbd-9f61-1c7d5fa3b4c7",
+    "title": "Übungen zu Stufe II — Leseverstehen",
+    "description": "Aufgaben für Lernende auf Mindeststandard-Niveau mit didaktischen Hinweisen für Lehrkräfte.",
+    "kind": "support",
+    "format": "application/pdf",
+    "language": "de",
+    "url": "https://materials.example.org/uebungen-stufe-ii-lesen.pdf",
+    "audience": "teacher",
+    "source": "IQB",
+    "attachments": [
+      {
+        "scope": "competence-level",
+        "refId": "II",
+        "refKind": "nameShort",
+        "subject": { "name": "Deutsch" },
+        "domain": { "name": "Leseverstehen" }
+      }
+    ]
+  },
+  {
+    "id": "a7b8c9d0-e1f2-4a3b-8c4d-5e6f7a8b9c0d",
+    "title": "Vertiefungsaufgaben Leseverstehen — Stufe III",
+    "description": "Ergänzende Leseaufgaben für Schülerinnen und Schüler auf Regelstandard-Niveau.",
+    "kind": "example",
+    "format": "application/pdf",
+    "language": "de",
+    "url": "https://materials.example.org/vertiefung-stufe-iii-lesen.pdf",
+    "audience": "teacher",
+    "source": "IQB",
+    "attachments": [
+      {
+        "scope": "competence-level",
+        "refId": "III",
+        "refKind": "nameShort",
+        "subject": { "name": "Deutsch" },
+        "domain": { "name": "Leseverstehen" }
+      }
+    ]
+  },
+  {
+    "id": "f1e2d3c4-b5a6-4978-8b9c-0d1e2f3a4b5c",
+    "title": "Enrichment: Anspruchsvolle Leseaufgaben — Stufe IV",
+    "description": "Transferaufgaben und anspruchsvolle Lesetexte für leistungsstarke Lernende.",
+    "kind": "example",
+    "format": "application/pdf",
+    "language": "de",
+    "url": "https://materials.example.org/enrichment-stufe-iv-lesen.pdf",
+    "audience": "teacher",
+    "source": "IQB",
+    "attachments": [
+      {
+        "scope": "competence-level",
+        "refId": "IV",
+        "refKind": "nameShort",
+        "subject": { "name": "Deutsch" },
+        "domain": { "name": "Leseverstehen" }
+      }
+    ]
+  },
+  {
+    "id": "b2c3d4e5-f6a7-48b9-9c0d-1e2f3a4b5c6d",
+    "title": "Lesetipps für starke Leserinnen und Leser",
+    "kind": "info",
+    "format": "text/html",
+    "language": "de",
+    "content": "<h1>Du liest sehr gut!</h1><p>Hier findest du Bücher und Texte, die dich herausfordern …</p>",
+    "audience": "student",
+    "attachments": [
+      {
+        "scope": "competence-level",
+        "refId": "IV",
+        "refKind": "nameShort",
+        "subject": { "name": "Deutsch" },
+        "domain": { "name": "Leseverstehen" }
+      }
+    ]
+  },
+  {
+    "id": "c5d6e7f8-a9b0-4c1d-ae2f-3a4b5c6d7e8f",
+    "title": "Erklärvideo: Wie lese ich die VERA-Ergebnisrückmeldung?",
+    "description": "Kurzfilm (ca. 4 min) für Lehrkräfte zur Interpretation des Kompetenzstufenberichts.",
+    "kind": "video",
+    "format": "video/mp4",
+    "language": "de",
+    "url": "https://materials.example.org/vera8-erklaervideo-ergebnisbericht.mp4",
+    "thumbnailUrl": "https://materials.example.org/vera8-erklaervideo-thumb.jpg",
+    "duration": 240,
+    "audience": "teacher",
+    "source": "IQB",
+    "tags": ["VERA", "Auswertung", "Kompetenzstufen"],
+    "attachments": [
+      { "scope": "general" }
+    ]
   }
 ]

--- a/docs/entwuerfe/materialien/beispiele/msk-aggregations-with-materials.json
+++ b/docs/entwuerfe/materialien/beispiele/msk-aggregations-with-materials.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "6a-mathe-msk",
+    "name": "6a Mathematik (MSK-Foerdergruppe)",
+    "type": "group",
+    "subject": { "id": "ma", "name": "Mathematik" },
+    "domain": { "id": "nz", "name": "Natuerliche Zahlen" },
+    "aggregations": [
+      {
+        "type": "competence",
+        "value": "Diagnosegeleitetheit",
+        "includedIqbIds": ["MSK-NZ-VC-01", "MSK-NZ-ZR-01"],
+        "descriptiveStatistics": { "frequency": 15, "total": 24, "mean": 0.62 },
+        "materials": [
+          {
+            "id": "msk-sek-natuerliche-zahlen-vorcheck-003",
+            "title": "Vor-Check: Natuerliche Zahlen (Klasse 3-5)",
+            "kind": "diagnostic"
+          }
+        ]
+      },
+      {
+        "type": "competence",
+        "value": "Verstehensorientierung",
+        "includedIqbIds": ["MSK-NZ-ZS-01", "MSK-NZ-ZR-01"],
+        "descriptiveStatistics": { "frequency": 13, "total": 24, "mean": 0.54 },
+        "materials": [
+          {
+            "id": "msk-sek-foerderbaustein-zahlenstrahl-004",
+            "title": "Foerderbaustein Zahlenstrahl (Sek I)",
+            "kind": "support"
+          }
+        ]
+      },
+      {
+        "type": "competence",
+        "value": "Kommunikationsfoerderung",
+        "includedIqbIds": ["MSK-NZ-ZS-01"],
+        "descriptiveStatistics": { "frequency": 10, "total": 24, "mean": 0.42 },
+        "materials": [
+          {
+            "id": "msk-general-prinzipien-001",
+            "title": "MSK-Leitprinzipien im Unterricht",
+            "kind": "didactic"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/docs/entwuerfe/materialien/beispiele/msk-competence-levels-with-materials.json
+++ b/docs/entwuerfe/materialien/beispiele/msk-competence-levels-with-materials.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "6a-mathe-msk",
+    "name": "6a Mathematik (MSK-Foerdergruppe)",
+    "type": "group",
+    "subject": { "id": "ma", "name": "Mathematik" },
+    "domain": { "id": "nz", "name": "Natuerliche Zahlen" },
+    "materials": [
+      {
+        "id": "msk-general-prinzipien-001",
+        "title": "MSK-Leitprinzipien im Unterricht",
+        "kind": "didactic",
+        "audience": "teacher"
+      }
+    ],
+    "competenceLevels": [
+      {
+        "id": "msk-level-basis",
+        "nameShort": "B",
+        "name": "Basiskompetenz unsicher",
+        "description": "Lernende benoetigen diagnosegeleitete Foerderung mit starker Kommunikationsunterstuetzung.",
+        "descriptiveStatistics": { "frequency": 8, "total": 24, "mean": 0.33 },
+        "materials": [
+          {
+            "id": "msk-sek-natuerliche-zahlen-vorcheck-003",
+            "title": "Vor-Check: Natuerliche Zahlen (Klasse 3-5)",
+            "kind": "diagnostic"
+          },
+          {
+            "id": "msk-sek-foerderbaustein-zahlenstrahl-004",
+            "title": "Foerderbaustein Zahlenstrahl (Sek I)",
+            "kind": "support"
+          }
+        ]
+      },
+      {
+        "id": "msk-level-aufbau",
+        "nameShort": "A",
+        "name": "Basiskompetenz im Aufbau",
+        "description": "Lernende zeigen erste Verstehensansaetze und profitieren von gestuften Lernpfaden.",
+        "descriptiveStatistics": { "frequency": 10, "total": 24, "mean": 0.42 },
+        "materials": [
+          {
+            "id": "msk-sek-foerderbaustein-zahlenstrahl-004",
+            "title": "Foerderbaustein Zahlenstrahl (Sek I)",
+            "kind": "support"
+          }
+        ]
+      },
+      {
+        "id": "msk-level-sicher",
+        "nameShort": "S",
+        "name": "Basiskompetenz sicher",
+        "description": "Lernende koennen Inhalte stabil anwenden und als Lernpartner unterstuetzen.",
+        "descriptiveStatistics": { "frequency": 6, "total": 24, "mean": 0.25 }
+      }
+    ]
+  }
+]

--- a/docs/entwuerfe/materialien/beispiele/msk-items-with-materials.json
+++ b/docs/entwuerfe/materialien/beispiele/msk-items-with-materials.json
@@ -1,0 +1,81 @@
+[
+  {
+    "id": "6a-mathe-msk",
+    "name": "6a Mathematik (MSK-Foerdergruppe)",
+    "type": "group",
+    "subject": { "id": "ma", "name": "Mathematik" },
+    "domain": { "id": "nz", "name": "Natuerliche Zahlen" },
+    "items": [
+      {
+        "id": "msk-item-vc-01",
+        "name": "VC1",
+        "position": 1,
+        "iqbId": "MSK-NZ-VC-01",
+        "exercise": {
+          "id": "msk-ex-nz-vorcheck",
+          "name": "Vor-Check Natuerliche Zahlen",
+          "materials": [
+            {
+              "id": "msk-sek-natuerliche-zahlen-vorcheck-003",
+              "title": "Vor-Check: Natuerliche Zahlen (Klasse 3-5)",
+              "kind": "diagnostic"
+            }
+          ]
+        },
+        "descriptiveStatistics": { "frequency": 9, "total": 24, "mean": 0.38 },
+        "materials": [
+          {
+            "id": "msk-online-check-dashboard-005",
+            "title": "Hinweise zum Online-Check und Dashboards",
+            "kind": "info",
+            "audience": "teacher"
+          }
+        ]
+      },
+      {
+        "id": "msk-item-zs-01",
+        "name": "ZS1",
+        "position": 2,
+        "iqbId": "MSK-NZ-ZS-01",
+        "exercise": {
+          "id": "msk-ex-zahlenstrahl",
+          "name": "Foerdereinheit Zahlenstrahl",
+          "materials": [
+            {
+              "id": "msk-sek-foerderbaustein-zahlenstrahl-004",
+              "title": "Foerderbaustein Zahlenstrahl (Sek I)",
+              "kind": "support"
+            }
+          ]
+        },
+        "descriptiveStatistics": { "frequency": 11, "total": 24, "mean": 0.46 },
+        "materials": [
+          {
+            "id": "msk-sek-foerderbaustein-zahlenstrahl-004",
+            "title": "Foerderbaustein Zahlenstrahl (Sek I)",
+            "kind": "support",
+            "audience": "teacher"
+          }
+        ]
+      },
+      {
+        "id": "msk-item-zr-01",
+        "name": "ZR1",
+        "position": 3,
+        "iqbId": "MSK-NZ-ZR-01",
+        "exercise": {
+          "id": "msk-ex-zahlen-ziffern",
+          "name": "Foerdereinheit Zahlen- und Ziffernrechnen"
+        },
+        "descriptiveStatistics": { "frequency": 7, "total": 24, "mean": 0.29 },
+        "materials": [
+          {
+            "id": "msk-general-prinzipien-001",
+            "title": "MSK-Leitprinzipien im Unterricht",
+            "kind": "didactic"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/docs/entwuerfe/materialien/beispiele/msk-material-list.json
+++ b/docs/entwuerfe/materialien/beispiele/msk-material-list.json
@@ -1,0 +1,89 @@
+[
+  {
+    "id": "msk-general-prinzipien-001",
+    "title": "MSK-Leitprinzipien im Unterricht",
+    "description": "Kurzfassung der drei MSK-Leitprinzipien: Diagnosegeleitetheit, Verstehensorientierung und Kommunikationsfoerderung.",
+    "kind": "didactic",
+    "format": "text/html",
+    "language": "de",
+    "content": "<h2>Leitprinzipien</h2><ul><li>Diagnosegeleitetheit</li><li>Verstehensorientierung</li><li>Kommunikationsfoerderung</li></ul>",
+    "audience": "teacher",
+    "source": "Mathe sicher koennen (DZLM)",
+    "tags": ["MSK", "Leitideen", "Unterrichtsentwicklung"],
+    "attachments": [
+      {
+        "scope": "general"
+      }
+    ]
+  },
+  {
+    "id": "msk-sek-natuerliche-zahlen-vorcheck-003",
+    "title": "Vor-Check: Natuerliche Zahlen (Klasse 3-5)",
+    "kind": "diagnostic",
+    "format": "application/pdf",
+    "language": "de",
+    "url": "https://mathe-sicher-koennen.dzlm.de/material-sek",
+    "audience": "teacher",
+    "source": "Mathe sicher koennen (DZLM)",
+    "tags": ["Vor-Check", "Natuerliche Zahlen", "Diagnose"],
+    "attachments": [
+      {
+        "scope": "exercise",
+        "refId": "msk-ex-nz-vorcheck",
+        "refName": "Vor-Check Natuerliche Zahlen"
+      },
+      {
+        "scope": "competence",
+        "refId": "msk-diagnosegeleitetheit",
+        "refName": "Diagnosegeleitetheit"
+      }
+    ]
+  },
+  {
+    "id": "msk-sek-foerderbaustein-zahlenstrahl-004",
+    "title": "Foerderbaustein Zahlenstrahl (Sek I)",
+    "description": "Foerdereinheit mit Lernpfad und gestuften Lernzielen fuer den sicheren Umgang mit dem Zahlenstrahl.",
+    "kind": "support",
+    "format": "application/pdf",
+    "language": "de",
+    "url": "https://mathe-sicher-koennen.dzlm.de/material-sek",
+    "audience": "teacher",
+    "source": "Mathe sicher koennen (DZLM)",
+    "tags": ["Foerderbaustein", "Zahlenstrahl", "Sek I"],
+    "attachments": [
+      {
+        "scope": "exercise",
+        "refId": "msk-ex-zahlenstrahl",
+        "refName": "Foerdereinheit Zahlenstrahl"
+      },
+      {
+        "scope": "item",
+        "refId": "MSK-NZ-ZS-01",
+        "refKind": "iqbId",
+        "refName": "Aufgabe Zahlenstrahl 1"
+      },
+      {
+        "scope": "competence-level",
+        "refId": "msk-level-basis",
+        "refName": "Basiskompetenz unsicher"
+      }
+    ]
+  },
+  {
+    "id": "msk-online-check-dashboard-005",
+    "title": "Hinweise zum Online-Check und Dashboards",
+    "kind": "info",
+    "format": "text/html",
+    "language": "de",
+    "url": "https://mathe-sicher-koennen.dzlm.de/online-check",
+    "audience": "teacher",
+    "source": "Mathe sicher koennen (DZLM)",
+    "tags": ["Online-Check", "Dashboard", "Auswertung"],
+    "attachments": [
+      {
+        "scope": "test",
+        "refId": "MSK-SEK-NZ-2026"
+      }
+    ]
+  }
+]

--- a/docs/entwuerfe/materialien/beispiele/vera-englisch-hoerverstehen-items.json
+++ b/docs/entwuerfe/materialien/beispiele/vera-englisch-hoerverstehen-items.json
@@ -1,0 +1,132 @@
+[
+  {
+    "name": "Klasse 8c",
+    "type": "group",
+    "subject": { "id": "en", "name": "Englisch" },
+    "domain": { "id": "hv", "name": "Hörverstehen" },
+    "materials": [
+      {
+        "id": "7a8b9c0d-e1f2-4a3b-8c4d-5e6f7a8b9c0d",
+        "title": "Durchführungshandreichung VERA-8 Englisch 2024",
+        "kind": "didactic",
+        "audience": "teacher"
+      },
+      {
+        "id": "8b9c0d1e-f2a3-4b4c-9d5e-6f7a8b9c0d1e",
+        "title": "Technischer Hinweis: Audiowiedergabe im Klassenraum",
+        "kind": "info",
+        "audience": "teacher"
+      }
+    ],
+    "items": [
+      {
+        "id": "9c0d1e2f-a3b4-4c5d-ae6f-7a8b9c0d1e2f",
+        "name": "3.1",
+        "position": 1,
+        "iqbId": "HV-EN-3001",
+        "exercise": {
+          "id": "ex-holiday-plans-001",
+          "name": "Holiday Plans",
+          "materials": [
+            {
+              "id": "0d1e2f3a-b4c5-4d6e-bf7a-8b9c0d1e2f3a",
+              "title": "Hörtext: 'Holiday Plans'",
+              "kind": "audio"
+            },
+            {
+              "id": "1e2f3a4b-c5d6-4e7f-c08b-9c0d1e2f3a4b",
+              "title": "Transkript: 'Holiday Plans'",
+              "kind": "transcript",
+              "audience": "teacher"
+            }
+          ]
+        },
+        "descriptiveStatistics": { "frequency": 14, "total": 25, "mean": 0.56 },
+        "materials": [
+          {
+            "id": "2f3a4b5c-d6e7-4f80-d19c-0d1e2f3a4b5c",
+            "title": "Musterlösung Item 3.1",
+            "kind": "solution",
+            "audience": "teacher"
+          }
+        ]
+      },
+      {
+        "id": "3a4b5c6d-e7f8-4a91-e2ad-1e2f3a4b5c6d",
+        "name": "3.2",
+        "position": 2,
+        "iqbId": "HV-EN-3002",
+        "exercise": {
+          "id": "ex-holiday-plans-001",
+          "name": "Holiday Plans",
+          "materials": [
+            {
+              "id": "0d1e2f3a-b4c5-4d6e-bf7a-8b9c0d1e2f3a",
+              "title": "Hörtext: 'Holiday Plans'",
+              "kind": "audio"
+            },
+            {
+              "id": "1e2f3a4b-c5d6-4e7f-c08b-9c0d1e2f3a4b",
+              "title": "Transkript: 'Holiday Plans'",
+              "kind": "transcript",
+              "audience": "teacher"
+            }
+          ]
+        },
+        "descriptiveStatistics": { "frequency": 11, "total": 25, "mean": 0.44 },
+        "materials": [
+          {
+            "id": "4b5c6d7e-f8a9-4b02-f3be-2f3a4b5c6d7e",
+            "title": "Musterlösung Item 3.2",
+            "kind": "solution",
+            "audience": "teacher"
+          },
+          {
+            "id": "5c6d7e8f-a9b0-4c13-04cf-3a4b5c6d7e8f",
+            "title": "Typische Fehlermuster zu Item 3.2",
+            "kind": "diagnostic",
+            "audience": "teacher"
+          }
+        ]
+      },
+      {
+        "id": "6d7e8f9a-b0c1-4d24-15d0-4b5c6d7e8f9a",
+        "name": "4.1",
+        "position": 3,
+        "iqbId": "HV-EN-4001",
+        "exercise": {
+          "id": "ex-city-tour-002",
+          "name": "City Tour",
+          "materials": [
+            {
+              "id": "7e8f9a0b-c1d2-4e35-26e1-5c6d7e8f9a0b",
+              "title": "Hörtext: 'City Tour'",
+              "kind": "audio"
+            },
+            {
+              "id": "8f9a0b1c-d2e3-4f46-37f2-6d7e8f9a0b1c",
+              "title": "Transkript: 'City Tour'",
+              "kind": "transcript",
+              "audience": "teacher"
+            },
+            {
+              "id": "9a0b1c2d-e3f4-4057-480a-7e8f9a0b1c2d",
+              "title": "Beispielaufgaben zum Aufgabenformat 'City Tour'",
+              "kind": "example",
+              "audience": "teacher"
+            }
+          ]
+        },
+        "descriptiveStatistics": { "frequency": 9, "total": 25, "mean": 0.36 },
+        "materials": [
+          {
+            "id": "0b1c2d3e-f4a5-4168-591b-8f9a0b1c2d3e",
+            "title": "Musterlösung Item 4.1",
+            "kind": "solution",
+            "audience": "teacher"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/docs/entwuerfe/materialien/paths/integration-api-yml.md
+++ b/docs/entwuerfe/materialien/paths/integration-api-yml.md
@@ -1,0 +1,57 @@
+# Integrationsskizze: Ergänzungen zu `api/api.yml`
+
+Damit sich die Materialien-Erweiterung in die bestehende Spec einfügt, müssten in
+`api/api.yml` folgende Ergänzungen erfolgen (hier nur als Referenz — der Entwurf
+selbst greift nicht in die Spec ein):
+
+```yaml
+tags:
+  - name: groups
+    description: Ergebnisse auf Ebene einer Lerngruppe
+  - name: schools
+    description: Ergebnisse zusammengefasst nach Schule
+  - name: states
+    description: Ergebnisse auf Landesebene
+  - name: materials           # NEU
+    description: Begleitmaterialien zu Tests, Aufgaben, Items, Kompetenzen und Kompetenzstufen
+
+paths:
+  # ... bestehende Pfade ...
+
+  /materials:                 # NEU
+    $ref: 'paths/materials/list.yml'
+  /materials/{id}:            # NEU
+    $ref: 'paths/materials/by-id.yml'
+```
+
+Optional (Convenience-Schicht pro Ebene):
+
+```yaml
+  /groups/{id}/materials:     # OPTIONAL
+    $ref: 'paths/groups/materials.yml'
+  /schools/{id}/materials:    # OPTIONAL
+    $ref: 'paths/schools/materials.yml'
+  /states/{id}/materials:     # OPTIONAL
+    $ref: 'paths/states/materials.yml'
+```
+
+Zusätzlich müssten die bestehenden Schemas ergänzt werden. Beispiel für
+`api/components/schemas/competence-level.yml`:
+
+```yaml
+type: object
+required:
+  - nameShort
+properties:
+  # ... bestehende Felder ...
+  materials:                  # NEU, optional
+    type: array
+    description: Materialien, die an diese Kompetenzstufe gebunden sind (kompakte Referenzen)
+    items:
+      $ref: './material-reference.yml'
+```
+
+Analog in `value-group.yml`, `exercise.yml`, `item.yml`, `competence.yml`.
+
+Alle Ergänzungen sind **additiv** — bestehende Backends und Frontends bleiben spec-konform,
+auch wenn sie die Materialien nicht kennen.

--- a/docs/entwuerfe/materialien/paths/materials-by-id.yml
+++ b/docs/entwuerfe/materialien/paths/materials-by-id.yml
@@ -1,0 +1,24 @@
+get:
+  operationId: getMaterialById
+  summary: Einzelnes Material abrufen
+  description: |
+    Liefert das vollständige Material-Objekt zu einer ID. Wird vor allem genutzt, wenn
+    in Auswertungs­responses nur kompakte `MaterialReference`-Objekte eingebettet waren
+    und das Frontend Details nachladen möchte.
+  tags:
+    - materials
+  parameters:
+    - in: path
+      name: id
+      required: true
+      schema: { type: string }
+      description: Material-ID
+  responses:
+    '200':
+      description: Material
+      content:
+        'application/json':
+          schema:
+            $ref: '../schemas/material.yml'
+    '404':
+      description: Material nicht gefunden

--- a/docs/entwuerfe/materialien/paths/materials-list.yml
+++ b/docs/entwuerfe/materialien/paths/materials-list.yml
@@ -1,0 +1,88 @@
+get:
+  operationId: getMaterials
+  summary: Materialien mit Bezug zu Auswertungsdaten abfragen
+  description: |
+    Liefert Materialien (Handreichungen, Fördermaterial, Musterlösungen, Audio, ...),
+    optional eingegrenzt auf bestimmte Bezugspunkte (Test, Aufgabe, Item,
+    Kompetenz/Leitidee, Kompetenzstufe) oder auf Material-Eigenschaften
+    (Art, Sprache, Zielgruppe).
+
+    Ohne Filter liefert das Backend **alle** ihm bekannten Materialien (optional paginiert
+    — Paginierung ist in dieser Spec-Version nicht standardisiert).
+  tags:
+    - materials
+  parameters:
+    - in: query
+      name: scope
+      schema: { type: string }
+      description: |
+        Kommasepariert. Filter auf Attachment-Scopes. Empfohlene Werte&#58;
+        `test`, `exercise`, `item`, `competence`, `competence-level`, `general`.
+      examples:
+        Kompetenzstufen:
+          value: competence-level
+        Aufgabe und Item:
+          value: exercise,item
+    - in: query
+      name: test
+      schema: { type: string }
+      description: Testheft-/Test-Kennung, für die Materialien geliefert werden sollen.
+    - in: query
+      name: exercise
+      schema: { type: string }
+      description: Aufgabe-ID.
+    - in: query
+      name: item
+      schema: { type: string }
+      description: |
+        Item-Kennung. Entweder interne `item.id` oder `iqbId:<IQBID>` um explizit die
+        IQB-Item-Id zu verwenden.
+      examples:
+        Interne ID:
+          value: b8d23653-3881-40de-a45a-d34e2dd191ed
+        IQB ID:
+          value: iqbId:AB1021
+    - in: query
+      name: competence
+      schema: { type: string }
+      description: |
+        Kompetenz-ID (auch Leitidee). Falls das Backend mit Kürzeln arbeitet, kann
+        `name:<Kürzel>` verwendet werden (z. B. `name:L1`).
+    - in: query
+      name: competenceLevel
+      schema: { type: string }
+      description: |
+        Kompetenzstufen-ID oder `nameShort:<Kürzel>` (z. B. `nameShort:Ia`).
+    - in: query
+      name: subject
+      schema: { type: string }
+      description: Fachkürzel (z. B. `de`, `ma`).
+    - in: query
+      name: domain
+      schema: { type: string }
+      description: Domänen-Kürzel (z. B. `le`, `rs`).
+    - in: query
+      name: kind
+      schema: { type: string }
+      description: Kommasepariert. Filter auf Material-Arten.
+    - in: query
+      name: language
+      schema: { type: string }
+      description: BCP47-Sprachcode.
+    - in: query
+      name: audience
+      schema: { type: string }
+      description: Zielgruppe (`teacher`, `student`, `parents`, ...).
+  responses:
+    '200':
+      description: Liste passender Materialien (evtl. leer)
+      content:
+        'application/json':
+          schema:
+            type: array
+            items:
+              $ref: '../schemas/material.yml'
+    '400':
+      description: Ungültige Anfrage, z.B. ungültige Werte für die Parameter
+    '501':
+      description: Backend unterstützt einen der Filter prinzipiell nicht

--- a/docs/entwuerfe/materialien/schemas/material-attachment.yml
+++ b/docs/entwuerfe/materialien/schemas/material-attachment.yml
@@ -1,0 +1,81 @@
+type: object
+description: |
+  Verknüpfung eines Materials mit einem Bezugspunkt in der Auswertungsstruktur.
+  `refId` ist außer bei `scope=general` zwingend.
+required:
+  - scope
+properties:
+  scope:
+    type: string
+    description: |
+      Art des Bezugspunkts. Offener String. Empfohlene Werte:
+      - `test`             - Material bezieht sich auf einen (Test-)Gesamtkontext
+      - `exercise`         - Bezug zu einer Aufgabe (`exercise.id`)
+      - `item`             - Bezug zu einem Item / einer Lösungshäufigkeit
+      - `competence`       - Bezug zu einer Kompetenz oder Leitidee (`competence.id`)
+      - `competence-level` - Bezug zu einer Kompetenzstufe (`competence-level.id`)
+      - `general`          - Allgemein, kein spezifischer Bezugspunkt
+    examples:
+      - competence-level
+      - exercise
+      - item
+      - competence
+      - test
+      - general
+  refId:
+    type: string
+    description: |
+      ID der verknüpften Entität. Pflicht außer bei `scope=general`.
+      Für `test` ist die testspezifische Kennung gemeint (z. B. Testheft-Id,
+      wie auch in `value-group.properties.booklet` üblich).
+    examples:
+      - 4ddfdc3e-79fd-47be-bbc0-341f403ac5db
+      - V8-2024-DE-TH01
+      - AB1021
+      - L1
+  refName:
+    type: string
+    description: |
+      Optionale menschenlesbare Kennung, falls hilfreich zur Anzeige oder wenn keine
+      stabile ID vorliegt (z. B. Kurzkennung der Kompetenzstufe, Itemname).
+    examples:
+      - 'Ia'
+      - '2.5.1'
+      - 'Leitidee Zahl'
+  refKind:
+    type: string
+    description: |
+      Qualifier bei mehrdeutigen ID-Räumen. Empfohlene Werte:
+      - `iqbId`        - `refId` ist eine IQB-Itemkennung
+      - `nameShort`    - `refId` ist das Kürzel (z. B. einer Kompetenzstufe)
+      - `internalId`   - `refId` ist eine backendinterne UUID
+      - `curriculumUri` - `refId` ist eine URI aus einem Kompetenz-/Curriculum-Vokabular
+        (z. B. aus dem KMK-/IQB-Bildungsstandards-Vokabular oder einem Landeslehrplan).
+        Diese URIs passen 1:1 in LRMI/AMB `alignmentObject.targetUrl` und erleichtern
+        den Übergang zu externen Metadaten erheblich.
+    examples:
+      - iqbId
+      - nameShort
+      - internalId
+      - curriculumUri
+  subject:
+    description: |
+      Optional&#58; Fach, auf das sich das Material bezieht. Struktur wie in
+      `value-group.subject`.
+    $ref: '../../../../api/components/schemas/subject.yml'
+  domain:
+    description: |
+      Optional&#58; Domäne, auf die sich das Material bezieht. Struktur wie in
+      `value-group.domain`.
+    $ref: '../../../../api/components/schemas/domain.yml'
+  properties:
+    type: array
+    description: Freie Key-Value-Metadaten zur Verknüpfung (z. B. Relevanz, Reihenfolge).
+    items:
+      type: object
+      required: ['key', 'value']
+      properties:
+        key:
+          type: string
+        value:
+          type: string

--- a/docs/entwuerfe/materialien/schemas/material-reference.yml
+++ b/docs/entwuerfe/materialien/schemas/material-reference.yml
@@ -1,0 +1,24 @@
+type: object
+description: |
+  Kompakte Referenz auf ein Material, wie sie in Auswertungs­responses eingebettet wird.
+  Das vollständige Material ist über `GET /materials/{id}` erreichbar.
+required:
+  - id
+properties:
+  id:
+    type: string
+    description: Verweis auf `Material.id`
+    examples:
+      - 9a21ad44-3e8b-4a1e-9f76-2a1e8a6b0e5a
+  title:
+    type: string
+    description: Zur Anzeige ohne zusätzliches Nachladen
+  kind:
+    type: string
+    description: Für Icon/Filter ohne Nachladen (siehe Material.kind)
+  url:
+    type: string
+    format: uri
+    description: Direktlink, wenn ohne Vorverarbeitung nutzbar
+  audience:
+    type: string

--- a/docs/entwuerfe/materialien/schemas/material.yml
+++ b/docs/entwuerfe/materialien/schemas/material.yml
@@ -1,0 +1,168 @@
+type: object
+description: |
+  Ein eigenständiges Material (Handreichung, Fördermaterial, Lesetext, Musterlösung, ...),
+  das über `attachments[]` einem oder mehreren Bezugspunkten der Auswertung
+  (Test, Leitidee/Kompetenz, Aufgabe, Item, Kompetenzstufe, allgemein) zugeordnet ist.
+required:
+  - id
+  - title
+  - kind
+  - attachments
+properties:
+  id:
+    type: string
+    description: Eindeutige Kennung des Materials
+    examples:
+      - 9a21ad44-3e8b-4a1e-9f76-2a1e8a6b0e5a
+  title:
+    type: string
+    description: Kurzer, sprechender Titel
+    examples:
+      - 'Förderheft Leseverstehen Stufe Ia'
+      - 'Transkript Hörverstehen Aufgabe 3'
+  description:
+    type: string
+    description: Längere, optionale Beschreibung
+  kind:
+    type: string
+    description: |
+      Art des Materials. Offener String. Empfohlene Werte (Stufe-2-Konvention):
+      `support`, `diagnostic`, `didactic`, `anchor-text`, `solution`, `example`,
+      `audio`, `video`, `transcript`, `info`, `other`.
+
+      Die Werte sind bewusst bewusst überschaubar gehalten. Wer feinere Klassifikation
+      braucht, kann zusätzlich `externalMetadata[]` nutzen und dort auf ein
+      AMB-/LRMI-`learningResourceType`-Vokabular (z. B. `https://w3id.org/kim/hcrt/`)
+      verweisen. Siehe README &sect; 8 für die Mapping-Tabelle.
+    examples:
+      - support
+      - diagnostic
+      - anchor-text
+      - solution
+  format:
+    type: string
+    description: MIME-Typ bzw. technisches Format
+    examples:
+      - application/pdf
+      - text/html
+      - video/mp4
+      - audio/mpeg
+  language:
+    type: string
+    description: Sprache des Materials als BCP47-Kennung
+    examples:
+      - de
+      - de-DE
+      - en
+  url:
+    type: string
+    format: uri
+    description: |
+      Direkter Link zum Material. Entweder `url` **oder** `content` muss gesetzt sein.
+      Das Backend kann pre-signed URLs verwenden oder Auth voraussetzen.
+    examples:
+      - https://materials.example.org/foerderheft-lesen-ia.pdf
+  content:
+    type: string
+    description: |
+      Inline-Inhalt für kleine Materialien (kurze Hinweise, Erklärtexte).
+      Format ist durch `format` angegeben (z. B. `text/html`, `text/markdown`).
+  thumbnailUrl:
+    type: string
+    format: uri
+  size:
+    type: integer
+    description: Größe in Bytes
+    minimum: 0
+  duration:
+    type: integer
+    description: Laufzeit in Sekunden (für Audio/Video)
+    minimum: 0
+  license:
+    type: string
+    description: SPDX-Kennung oder Freitext-Lizenzhinweis
+    examples:
+      - CC-BY-4.0
+      - IQB Nutzungsbedingungen
+  source:
+    type: string
+    description: Herkunft / Autor / Institution
+    examples:
+      - IQB
+      - VERA
+      - Schulträger Musterstadt
+  version:
+    type: string
+  audience:
+    type: string
+    description: Zielgruppe. Empfohlene Werte&#58; `teacher`, `student`, `parents`, `other`.
+    examples:
+      - teacher
+      - student
+      - parents
+  tags:
+    type: array
+    description: Freie Schlagworte
+    items:
+      type: string
+  properties:
+    type: array
+    description: Freie Key-Value-Metadaten (analog zu value-group.yml)
+    items:
+      type: object
+      required: ['key', 'value']
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+  attachments:
+    type: array
+    description: |
+      Bezugspunkte des Materials. Mindestens ein Eintrag. Ein Material kann gleichzeitig
+      an mehrere Entitäten hängen (z. B. eine Kompetenzstufe UND eine Leitidee).
+    minItems: 1
+    items:
+      $ref: './material-attachment.yml'
+  externalMetadata:
+    type: array
+    description: |
+      Optionale Verweise auf externe Metadatensätze (LRMI, AMB, LOM, schema.org, ...),
+      unter denen dieses Material in einem anderen Metadatenschema vollständig beschrieben
+      ist. Dient der Interoperabilität mit OER-Repositories (edu-sharing,
+      WirLernenOnline, Bildungsserver, ...). **Keine Duplikation** der TBA3-Kernfelder —
+      wer die reichen Metadaten braucht, dereferenziert `url` und liest das Zielschema.
+    items:
+      type: object
+      required: ['schema', 'url']
+      properties:
+        schema:
+          type: string
+          description: |
+            Kennung des referenzierten Metadatenschemas. Empfohlene Werte:
+            - `amb`        - Allgemeines Metadatenprofil für Bildungsressourcen (DINI-AG KIM)
+            - `lrmi`       - Learning Resource Metadata Initiative (schema.org)
+            - `lom`        - IEEE LOM 1484.12.1
+            - `lom-de`     - deutsches Anwendungsprofil von LOM
+            - `schema.org` - generisches schema.org
+          examples:
+            - amb
+            - lrmi
+            - lom
+        url:
+          type: string
+          format: uri
+          description: URL, unter der der externe Metadatensatz abrufbar ist (JSON-LD, XML, ...)
+          examples:
+            - https://wirlernenonline.de/entry/abc123.jsonld
+        inlineId:
+          type: string
+          description: |
+            Falls das Zielschema eine eigenständige, URL-unabhängige Kennung verwendet
+            (z. B. LOM `identifier.entry`), kann diese hier transportiert werden.
+        mediaType:
+          type: string
+          description: MIME-Typ des Metadatensatzes, z. B. `application/ld+json`, `application/xml`.
+          examples:
+            - application/ld+json
+            - application/xml


### PR DESCRIPTION
## Summary
- fügt einen WIP-Entwurf für eine additive Materialien-Erweiterung der TBA3-Schnittstelle unter `docs/entwuerfe/materialien/` hinzu
- schlägt neue Material-Schemas, `/materials`-Pfadskizzen sowie Integrationshinweise für die bestehende OpenAPI-Struktur vor
- enthält JSON-Beispiele inkl. LRMI/AMB-Brücke (`externalMetadata`) und Referenzmodell für Test/Leitidee/Aufgabe/Item/Kompetenzstufe/allgemein

## Test plan
- [x] Entwurfsdokumentation auf Vollständigkeit geprüft
- [x] YAML-/JSON-Dateien konsistent strukturiert
- [ ] Review durch API-Owner (Semantik, Namensgebung, Scope)
- [ ] Entscheidung, welche Teile in eine offizielle Spezifikationsänderung überführt werden


Made with [Cursor](https://cursor.com)